### PR TITLE
Add analysis workspace and queued execution backend model

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,23 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./lib/algorithms", async () => {
+  const actual = await vi.importActual<typeof import("./lib/algorithms")>("./lib/algorithms");
+  return {
+    ...actual,
+    sampleQaoaMeasurementEstimate: vi.fn(actual.sampleQaoaMeasurementEstimate),
+    sampleVqeMeasurementEstimate: vi.fn(actual.sampleVqeMeasurementEstimate),
+  };
+});
+
 import App from "./App";
+import { sampleQaoaMeasurementEstimate, sampleVqeMeasurementEstimate } from "./lib/algorithms";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
 
 describe("App", () => {
   it("keeps rendering when a node is removed from the QAOA graph", async () => {
@@ -17,6 +33,7 @@ describe("App", () => {
     expect(screen.getByText("Nodes: 3")).toBeInTheDocument();
     expect(screen.getByText("Edges: 2")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /circuit visualizer/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /analysis workspace/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /energy landscape/i })).toBeInTheDocument();
   });
 
@@ -66,5 +83,112 @@ describe("App", () => {
 
     expect(screen.getByLabelText(/min lr/i)).toHaveAttribute("max", "0.01");
     expect(screen.getByText(/effective now: 0\.0100/i)).toBeInTheDocument();
+  });
+
+  it("renders an exact-vs-sampled dashboard for QAOA circuits", async () => {
+    const user = userEvent.setup();
+    vi.mocked(sampleQaoaMeasurementEstimate).mockReturnValue({
+      bitstrings: ["0011", "0011", "1100", "0011"],
+      estimatedValue: 3.25,
+      totalShotsUsed: 4,
+    });
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/measurement shots per batch/i), { target: { value: "4" } });
+    await user.click(screen.getByRole("button", { name: /refresh sampled estimate/i }));
+
+    expect(sampleQaoaMeasurementEstimate).toHaveBeenCalledWith(
+      4,
+      ["0-1", "1-2", "2-3", "3-0"],
+      [0.7, 0.35],
+      [0.35, 0.175],
+      4,
+      "dense-cpu",
+    );
+    expect(screen.getAllByText("3.250000")).toHaveLength(2);
+    expect(screen.getByText(/shot budget used: 4 total measurements across one basis/i)).toBeInTheDocument();
+    expect(screen.getByText(/histogram basis shots: 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/unique outcomes: 2/i)).toBeInTheDocument();
+    expect(screen.getByText("0011")).toBeInTheDocument();
+    expect(screen.getByText(/3 \/ 4 shots \(75\.0%\)/i)).toBeInTheDocument();
+  });
+
+  it("renders an exact-vs-sampled dashboard for VQE circuits", async () => {
+    const user = userEvent.setup();
+    vi.mocked(sampleVqeMeasurementEstimate).mockReturnValue({
+      bitstrings: ["10", "10", "01"],
+      estimatedValue: -1.2345,
+      totalShotsUsed: 6,
+    });
+
+    render(<App />);
+
+    await user.selectOptions(screen.getAllByRole("combobox")[0], "vqe");
+    fireEvent.change(screen.getByLabelText(/measurement shots per batch/i), { target: { value: "3" } });
+    await user.click(screen.getByRole("button", { name: /refresh sampled estimate/i }));
+
+    expect(sampleVqeMeasurementEstimate).toHaveBeenCalledWith(
+      [0.25, 0.125, 0.08333333333333333, 0.0625],
+      "H2_0.74",
+      3,
+      "dense-cpu",
+    );
+    expect(screen.getAllByText("-1.234500")).toHaveLength(2);
+    expect(screen.getByText(/shot budget used: 6 total measurements across multiple bases/i)).toBeInTheDocument();
+    expect(screen.getByText(/histogram basis shots: 3/i)).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText(/2 \/ 3 shots \(66\.7%\)/i)).toBeInTheDocument();
+  });
+
+  it("queues remote sampling jobs instead of resolving them locally", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.selectOptions(screen.getByLabelText(/execution target/i), "ionq-simulator");
+    await user.click(screen.getByRole("button", { name: /refresh sampled estimate/i }));
+
+    expect(sampleQaoaMeasurementEstimate).not.toHaveBeenCalled();
+    expect(screen.getAllByText(/queued remote target/i)).toHaveLength(2);
+    expect(screen.getByText(/ionq simulator · shot-sampling/i)).toBeInTheDocument();
+    expect(screen.getByText(/^queued$/i)).toBeInTheDocument();
+  });
+
+  it("polls queued remote jobs into a running state", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.selectOptions(screen.getByLabelText(/execution target/i), "ionq-qpu");
+    await user.click(screen.getByRole("button", { name: /refresh sampled estimate/i }));
+
+    expect(screen.getByText(/^queued$/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /poll jobs/i }));
+
+    expect(screen.getByText(/^running$/i)).toBeInTheDocument();
+    expect(screen.getByText(/acknowledged the job/i)).toBeInTheDocument();
+    expect(screen.getByText(/attempts: 1/i)).toBeInTheDocument();
+  });
+
+  it("persists backend target selection and IonQ credentials locally", async () => {
+    const user = userEvent.setup();
+
+    const { unmount } = render(<App />);
+
+    await user.selectOptions(screen.getByLabelText(/execution target/i), "ionq-simulator");
+
+    expect(screen.getByLabelText(/execution target/i)).toHaveValue("ionq-simulator");
+    expect(screen.getByLabelText(/ionq api key/i)).toBeInTheDocument();
+    expect(screen.getByText(/results may return much later/i)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/ionq api key/i), "test-ionq-key");
+
+    unmount();
+    render(<App />);
+
+    expect(screen.getByLabelText(/execution target/i)).toHaveValue("ionq-simulator");
+    expect(screen.getByLabelText(/ionq api key/i)).toHaveValue("test-ionq-key");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { ExecutionBackendPanel } from "./components/ExecutionBackendPanel";
+import { ExecutionJobsPanel } from "./components/ExecutionJobsPanel";
 import { HeaderBar } from "./components/HeaderBar";
 import { TargetDomainWidget } from "./components/TargetDomainWidget";
 import { DepthSlider } from "./components/DepthSlider";
@@ -11,18 +13,31 @@ import { CircuitVisualizer } from "./components/CircuitVisualizer";
 import { EnergyChart } from "./components/EnergyChart";
 import { type MoleculeKey } from "./data/molecules";
 import {
+  buildQaoaExecutionCircuit,
+  buildVqeExecutionCircuit,
   computeQaoaObjectiveGradients,
   computeVqeObjectiveGradients,
   evaluateQaoaCost,
   evaluateVqeEnergy,
 } from "./lib/algorithms";
+import { loadBackendPreferences, saveBackendPreferences, type BackendPreferences } from "./lib/backendPreferences";
+import { getBackendTargetDescriptor } from "./lib/backendTargets";
 import { buildQaoaCircuit, buildVqeCircuit } from "./lib/circuitBuilders";
+import {
+  loadExecutionJobs,
+  pollExecutionJobs,
+  retryExecutionJob,
+  saveExecutionJobs,
+  submitSamplingExecutionJob,
+  type ExecutionJobRecord,
+} from "./lib/executionJobs";
 import {
   edgeKey,
   filterEdgesForNodeCount,
   makeDefaultBetas,
   makeDefaultGammas,
   makeDefaultThetas,
+  parseAndValidateEdge,
   resizeArray,
 } from "./lib/utils";
 import type { Algorithm, CircuitMode } from "./types";
@@ -41,6 +56,20 @@ type LiveState = {
   vqeEarlyStop: VqeEarlyStopConfig;
   iteration: number;
 };
+
+type SampledOutcome = {
+  bitstring: string;
+  count: number;
+  probability: number;
+};
+
+type SampledMetricSummary = {
+  estimate: number;
+  totalShotsUsed: number;
+};
+
+const MAX_RENDERED_OUTCOMES = 8;
+const SHOT_PRESETS = [64, 256, 1024] as const;
 
 const getEffectiveLearningRate = (
   algorithm: Algorithm,
@@ -62,9 +91,26 @@ const clampVqeDecayConfig = (config: VqeDecayConfig, baseLearningRate: number): 
   minLearningRate: Math.min(config.minLearningRate, baseLearningRate),
 });
 
+const summarizeBitstrings = (bitstrings: string[]): SampledOutcome[] => {
+  const counts = new Map<string, number>();
+  for (const bitstring of bitstrings) {
+    counts.set(bitstring, (counts.get(bitstring) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([bitstring, count]) => ({
+      bitstring,
+      count,
+      probability: count / bitstrings.length,
+    }))
+    .sort((a, b) => b.count - a.count || a.bitstring.localeCompare(b.bitstring));
+};
+
 export default function App(): JSX.Element {
   const [algorithm, setAlgorithm] = useState<Algorithm>("qaoa");
   const [circuitMode, setCircuitMode] = useState<CircuitMode>("logical");
+  const [backendPreferences, setBackendPreferences] = useState<BackendPreferences>(() => loadBackendPreferences());
+  const [executionJobs, setExecutionJobs] = useState<ExecutionJobRecord[]>(() => loadExecutionJobs());
 
   const [depth, setDepth] = useState<number>(2);
   const [gammas, setGammas] = useState<number[]>(() => makeDefaultGammas(2));
@@ -99,8 +145,17 @@ export default function App(): JSX.Element {
     minIterations: 50,
   });
   const [stopReason, setStopReason] = useState<"converged" | null>(null);
+  const [measurementShots, setMeasurementShots] = useState<number>(256);
+  const [sampledBitstrings, setSampledBitstrings] = useState<string[]>([]);
+  const [sampledMetric, setSampledMetric] = useState<SampledMetricSummary | null>(null);
+  const [samplingError, setSamplingError] = useState<string | null>(null);
+  const [samplingNotice, setSamplingNotice] = useState<string | null>(null);
   const vqeStallRef = useRef<number>(0);
   const effectiveEdges = useMemo(() => filterEdgesForNodeCount(edges, nodeCount), [edges, nodeCount]);
+  const selectedExecutionTargetDescriptor = useMemo(
+    () => getBackendTargetDescriptor(backendPreferences.executionTarget),
+    [backendPreferences.executionTarget],
+  );
 
   const currentMetric = useMemo(() => {
     if (algorithm === "qaoa") {
@@ -108,6 +163,13 @@ export default function App(): JSX.Element {
     }
     return evaluateVqeEnergy(thetas, molecule);
   }, [algorithm, betas, effectiveEdges, gammas, molecule, nodeCount, thetas]);
+
+  const sampledOutcomeSummary = useMemo(() => summarizeBitstrings(sampledBitstrings), [sampledBitstrings]);
+  const sampledMetricDelta = sampledMetric ? sampledMetric.estimate - currentMetric : null;
+  const sampledRelativeError =
+    sampledMetricDelta !== null && Math.abs(currentMetric) > 1e-9
+      ? (Math.abs(sampledMetricDelta) / Math.abs(currentMetric)) * 100
+      : null;
 
   useEffect(() => {
     setRunning(false);
@@ -142,6 +204,21 @@ export default function App(): JSX.Element {
       setCostHistory([currentMetric]);
     }
   }, [currentMetric, iteration, running]);
+
+  useEffect(() => {
+    setSampledBitstrings([]);
+    setSampledMetric(null);
+    setSamplingError(null);
+    setSamplingNotice(null);
+  }, [algorithm, betas, effectiveEdges, gammas, measurementShots, molecule, nodeCount, thetas]);
+
+  useEffect(() => {
+    saveBackendPreferences(backendPreferences);
+  }, [backendPreferences]);
+
+  useEffect(() => {
+    saveExecutionJobs(executionJobs);
+  }, [executionJobs]);
 
   const liveRef = useRef<LiveState>({
     algorithm,
@@ -242,6 +319,14 @@ export default function App(): JSX.Element {
     return buildVqeCircuit(circuitMode, thetas);
   }, [algorithm, betas, circuitMode, effectiveEdges, gammas, nodeCount, thetas]);
 
+  const currentExecutableCircuit = useMemo(() => {
+    if (algorithm === "qaoa") {
+      const edgePairs = effectiveEdges.map((edge) => parseAndValidateEdge(edge, nodeCount));
+      return buildQaoaExecutionCircuit(nodeCount, edgePairs, gammas, betas);
+    }
+    return buildVqeExecutionCircuit(thetas);
+  }, [algorithm, betas, effectiveEdges, gammas, nodeCount, thetas]);
+
   const qubitCount = algorithm === "qaoa" ? nodeCount : 2;
   const effectiveLearningRate = getEffectiveLearningRate(
     algorithm,
@@ -312,6 +397,51 @@ export default function App(): JSX.Element {
     setIteration(0);
   };
 
+  const handleSampleBitstrings = () => {
+    if (running) return;
+
+    try {
+      const job =
+        algorithm === "qaoa"
+          ? submitSamplingExecutionJob({
+              targetId: backendPreferences.executionTarget,
+              circuit: currentExecutableCircuit,
+              algorithm: "qaoa",
+              shots: measurementShots,
+              nodeCount,
+              edges: effectiveEdges,
+              gammas,
+              betas,
+            })
+          : submitSamplingExecutionJob({
+              targetId: backendPreferences.executionTarget,
+              circuit: currentExecutableCircuit,
+              algorithm: "vqe",
+              shots: measurementShots,
+              thetas,
+              molecule,
+            });
+
+      setExecutionJobs((prev) => [job, ...prev].slice(0, 24));
+
+      if (job.result) {
+        setSampledBitstrings(job.result.bitstrings);
+        setSampledMetric({
+          estimate: job.result.estimate,
+          totalShotsUsed: job.result.totalShotsUsed,
+        });
+      }
+
+      setSamplingError(null);
+      setSamplingNotice(job.statusDetail);
+    } catch (error) {
+      setSampledBitstrings([]);
+      setSampledMetric(null);
+      setSamplingNotice(null);
+      setSamplingError(error instanceof Error ? error.message : "Unable to sample bitstrings.");
+    }
+  };
+
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100">
       <div className="pointer-events-none absolute inset-0 opacity-30">
@@ -324,6 +454,33 @@ export default function App(): JSX.Element {
 
         <div className="grid gap-4 lg:grid-cols-[minmax(300px,340px)_minmax(0,1fr)]">
           <aside className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-900/80 p-4">
+            <ExecutionBackendPanel
+              executionTarget={backendPreferences.executionTarget}
+              ionqApiKey={backendPreferences.ionqApiKey}
+              onExecutionTargetChange={(executionTarget) =>
+                setBackendPreferences((prev) => ({
+                  ...prev,
+                  executionTarget,
+                }))
+              }
+              onIonqApiKeyChange={(ionqApiKey) =>
+                setBackendPreferences((prev) => ({
+                  ...prev,
+                  ionqApiKey,
+                }))
+              }
+            />
+            <ExecutionJobsPanel
+              jobs={executionJobs}
+              onClearHistory={() => setExecutionJobs([])}
+              onPollJobs={() => setExecutionJobs((prev) => pollExecutionJobs(prev))}
+              onRetryJob={(jobId) =>
+                setExecutionJobs((prev) =>
+                  prev.map((job) => (job.id === jobId && job.status === "failed" ? retryExecutionJob(job) : job)),
+                )
+              }
+            />
+
             <TargetDomainWidget
               algorithm={algorithm}
               running={running}
@@ -397,6 +554,11 @@ export default function App(): JSX.Element {
             {stopReason === "converged" ? (
               <p className="text-xs text-emerald-300">Optimizer stopped early: convergence threshold reached.</p>
             ) : null}
+            {selectedExecutionTargetDescriptor.executionMode === "remote-job" ? (
+              <p className="text-xs text-cyan-300">
+                Local preview stays available while the selected execution target is modeled as a queued remote job.
+              </p>
+            ) : null}
           </aside>
 
           <main className="space-y-4">
@@ -407,14 +569,175 @@ export default function App(): JSX.Element {
               qubitCount={qubitCount}
             />
 
-            <EnergyChart
-              algorithm={algorithm}
-              molecule={molecule}
-              edges={effectiveEdges}
-              costHistory={costHistory}
-              currentMetric={currentMetric}
-              iteration={iteration}
-            />
+            <section className="rounded-2xl border border-neutral-800 bg-neutral-900/80 p-4">
+              <div className="mb-4 flex flex-col gap-3 border-b border-neutral-800 pb-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-neutral-200">Analysis Workspace</h2>
+                  <p className="mt-1 text-sm text-neutral-400">
+                    Track optimization progress in the energy landscape, then compare the exact result against finite-shot sampling.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">
+                  <span className="rounded-full border border-neutral-700 px-2 py-1">{algorithm === "qaoa" ? "QAOA" : "VQE"}</span>
+                  <span className="rounded-full border border-neutral-700 px-2 py-1">{qubitCount} qubits</span>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <EnergyChart
+                  algorithm={algorithm}
+                  molecule={molecule}
+                  edges={effectiveEdges}
+                  costHistory={costHistory}
+                  currentMetric={currentMetric}
+                  iteration={iteration}
+                  variant="embedded"
+                />
+
+                <section className="rounded-xl border border-neutral-800 bg-neutral-950/40 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-neutral-100">Measurement Dashboard</h3>
+                      <p className="mt-1 text-xs text-neutral-400">
+                        Compare the exact {algorithm === "qaoa" ? "QAOA cost" : "VQE energy"} against a finite-shot estimate.
+                      </p>
+                      <p className="mt-1 text-[11px] text-neutral-500">
+                        {algorithm === "qaoa"
+                          ? "Sampling uses one computational-basis batch over the current graph state."
+                          : "Sampling uses one computational-basis batch plus one rotated-basis batch to estimate the XX term."}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-neutral-700 px-2 py-1 text-[11px] uppercase tracking-[0.2em] text-neutral-300">
+                      Histogram + estimate
+                    </span>
+                  </div>
+
+                  <div className="mt-4 grid gap-2 sm:grid-cols-3">
+                    <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Exact {algorithm === "qaoa" ? "cost" : "energy"}</p>
+                      <p className="mt-2 font-mono text-lg text-neutral-100">{currentMetric.toFixed(6)}</p>
+                    </div>
+                    <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Sampled estimate</p>
+                      <p className="mt-2 font-mono text-lg text-cyan-300">
+                        {sampledMetric ? sampledMetric.estimate.toFixed(6) : "Awaiting samples"}
+                      </p>
+                    </div>
+                    <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Absolute error</p>
+                      <p className="mt-2 font-mono text-lg text-amber-300">
+                        {sampledMetricDelta !== null ? Math.abs(sampledMetricDelta).toFixed(6) : "Awaiting samples"}
+                      </p>
+                      <p className="mt-1 text-xs text-neutral-500">
+                        {sampledRelativeError !== null
+                          ? `${sampledRelativeError.toFixed(2)}% relative error`
+                          : "Capture measurements to compare."}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+                    <div className="space-y-2">
+                      <label className="block text-xs font-medium text-neutral-300" htmlFor="measurement-shots">
+                        <span className="mb-1 block">Measurement shots per batch</span>
+                        <input
+                          id="measurement-shots"
+                          type="number"
+                          min={1}
+                          max={4096}
+                          step={1}
+                          value={measurementShots}
+                          onChange={(event) => {
+                            const nextValue = Number.parseInt(event.target.value, 10);
+                            setMeasurementShots(
+                              Number.isFinite(nextValue) ? Math.min(4096, Math.max(1, nextValue)) : 1,
+                            );
+                          }}
+                          disabled={running}
+                          className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none transition focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+                      </label>
+                      <div className="flex flex-wrap gap-2">
+                        {SHOT_PRESETS.map((preset) => (
+                          <button
+                            key={preset}
+                            type="button"
+                            onClick={() => setMeasurementShots(preset)}
+                            disabled={running}
+                            className={`rounded-full border px-2.5 py-1 text-xs transition ${
+                              measurementShots === preset
+                                ? "border-cyan-500 bg-cyan-500/15 text-cyan-200"
+                                : "border-neutral-700 bg-neutral-900 text-neutral-400 hover:border-neutral-500 hover:text-neutral-200"
+                            } disabled:cursor-not-allowed disabled:opacity-60`}
+                          >
+                            {preset} shots
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={handleSampleBitstrings}
+                      disabled={running}
+                      className="rounded-md border border-cyan-700 bg-cyan-900/40 px-3 py-2 text-sm font-medium text-cyan-200 transition hover:bg-cyan-900/60 disabled:cursor-not-allowed disabled:border-neutral-700 disabled:bg-neutral-800 disabled:text-neutral-500"
+                    >
+                      Refresh sampled estimate
+                    </button>
+                  </div>
+
+                  {sampledMetric ? (
+                    <p className="mt-3 text-xs text-neutral-400">
+                      Shot budget used: {sampledMetric.totalShotsUsed} total measurements
+                      {sampledMetric.totalShotsUsed === measurementShots ? " across one basis." : " across multiple bases."}
+                    </p>
+                  ) : null}
+                  {running ? (
+                    <p className="mt-3 text-xs text-amber-300">Pause the optimizer before sampling the current state.</p>
+                  ) : null}
+                  {samplingNotice ? <p className="mt-3 text-xs text-cyan-300">{samplingNotice}</p> : null}
+                  {samplingError ? <p className="mt-3 text-xs text-red-300">{samplingError}</p> : null}
+
+                  {sampledBitstrings.length > 0 ? (
+                    <div className="mt-4 space-y-3">
+                      <div className="flex items-center justify-between text-xs text-neutral-400">
+                        <span>Histogram basis shots: {sampledBitstrings.length}</span>
+                        <span>Unique outcomes: {sampledOutcomeSummary.length}</span>
+                      </div>
+
+                      <ul className="space-y-2">
+                        {sampledOutcomeSummary.slice(0, MAX_RENDERED_OUTCOMES).map((outcome) => (
+                          <li key={outcome.bitstring}>
+                            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+                              <span className="font-mono text-sm text-neutral-100">{outcome.bitstring}</span>
+                              <span className="text-neutral-400">
+                                {outcome.count} / {sampledBitstrings.length} shots ({(outcome.probability * 100).toFixed(1)}%)
+                              </span>
+                            </div>
+                            <div className="h-3 overflow-hidden rounded-full bg-neutral-800">
+                              <div
+                                className="h-full rounded-full bg-cyan-400"
+                                style={{ width: `${Math.max(outcome.probability * 100, 2)}%` }}
+                              />
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+
+                      {sampledOutcomeSummary.length > MAX_RENDERED_OUTCOMES ? (
+                        <p className="text-xs text-neutral-500">
+                          Showing the top {MAX_RENDERED_OUTCOMES} outcomes by observed frequency.
+                        </p>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-xs text-neutral-500">
+                      No sampled histogram yet. Capture measurements to compare exact and finite-shot behavior.
+                    </p>
+                  )}
+                </section>
+              </div>
+            </section>
           </main>
         </div>
       </div>

--- a/src/components/EnergyChart.tsx
+++ b/src/components/EnergyChart.tsx
@@ -9,6 +9,7 @@ type EnergyChartProps = {
   costHistory: number[];
   currentMetric: number;
   iteration: number;
+  variant?: "standalone" | "embedded";
 };
 
 export function EnergyChart({
@@ -18,6 +19,7 @@ export function EnergyChart({
   costHistory,
   currentMetric,
   iteration,
+  variant = "standalone",
 }: EnergyChartProps): JSX.Element {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
@@ -66,9 +68,13 @@ export function EnergyChart({
   };
 
   const metricLabel = algorithm === "vqe" ? "ENERGY (HARTREES)" : "COST (EXPECTATION VAL)";
+  const containerClassName =
+    variant === "embedded"
+      ? "rounded-xl border border-neutral-800 bg-neutral-950/50 p-4"
+      : "rounded-xl border border-neutral-800 bg-neutral-900/80 p-4";
 
   return (
-    <section className="rounded-xl border border-neutral-800 bg-neutral-900/80 p-4">
+    <section className={containerClassName}>
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-sm font-semibold uppercase tracking-widest text-neutral-300">Energy Landscape</h2>
         <div className="flex flex-col items-end text-xs text-neutral-400">

--- a/src/components/ExecutionBackendPanel.tsx
+++ b/src/components/ExecutionBackendPanel.tsx
@@ -1,0 +1,121 @@
+import {
+  getBackendTargetDescriptor,
+  listBackendTargets,
+  type BackendTargetId,
+  type BackendTargetDescriptor,
+} from "../lib/backendTargets";
+
+type ExecutionBackendPanelProps = {
+  executionTarget: BackendTargetId;
+  ionqApiKey: string;
+  onExecutionTargetChange: (target: BackendTargetId) => void;
+  onIonqApiKeyChange: (apiKey: string) => void;
+};
+
+const formatIntentLabel = (intent: BackendTargetDescriptor["supportedIntents"][number]): string => {
+  switch (intent) {
+    case "expectation-values":
+      return "Expectation values";
+    case "shot-sampling":
+      return "Shot sampling";
+    case "state-vector":
+      return "State vector";
+    default:
+      return intent;
+  }
+};
+
+export function ExecutionBackendPanel({
+  executionTarget,
+  ionqApiKey,
+  onExecutionTargetChange,
+  onIonqApiKeyChange,
+}: ExecutionBackendPanelProps): JSX.Element {
+  const descriptor = getBackendTargetDescriptor(executionTarget);
+  const isRemoteTarget = descriptor.executionMode === "remote-job";
+  const targetOptions = listBackendTargets();
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-neutral-300">Execution Backend</h2>
+
+      <div className="space-y-3 rounded-lg border border-neutral-800 bg-neutral-950/60 p-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-neutral-300" htmlFor="execution-target">
+            Execution target
+          </label>
+          <select
+            id="execution-target"
+            value={executionTarget}
+            onChange={(event) => onExecutionTargetChange(event.target.value as BackendTargetId)}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm outline-none ring-cyan-400 focus:ring-2"
+          >
+            {targetOptions.map((target) => (
+              <option key={target.id} value={target.id}>
+                {target.label}
+                {target.implementationStatus === "planned" ? " (planned)" : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">
+          <span className="rounded-full border border-neutral-700 px-2 py-1">{descriptor.provider}</span>
+          <span className="rounded-full border border-neutral-700 px-2 py-1">
+            {descriptor.executionMode === "local-sync" ? "Local sync" : "Remote job"}
+          </span>
+          <span
+            className={`rounded-full border px-2 py-1 ${
+              descriptor.implementationStatus === "implemented"
+                ? "border-emerald-700 text-emerald-300"
+                : "border-amber-700 text-amber-300"
+            }`}
+          >
+            {descriptor.implementationStatus}
+          </span>
+        </div>
+
+        <p className="text-xs text-neutral-400">{descriptor.notes}</p>
+
+        <div className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+          <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Supported intents</p>
+          <p className="mt-2 text-sm text-neutral-200">
+            {descriptor.supportedIntents.map((intent) => formatIntentLabel(intent)).join(", ")}
+          </p>
+        </div>
+
+        {descriptor.provider === "ionq" ? (
+          <div className="space-y-2 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+            <label className="block text-xs font-medium text-neutral-300" htmlFor="ionq-api-key">
+              IonQ API key
+            </label>
+            <input
+              id="ionq-api-key"
+              type="password"
+              value={ionqApiKey}
+              onChange={(event) => onIonqApiKeyChange(event.target.value)}
+              placeholder="Enter IonQ API key"
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none transition focus:border-cyan-500"
+            />
+            <div className="flex items-center justify-between gap-3 text-xs text-neutral-500">
+              <span>Stored locally in this browser until provider secret handling is added.</span>
+              <span className={ionqApiKey ? "text-emerald-300" : "text-amber-300"}>
+                {ionqApiKey ? "Configured" : "Missing"}
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="rounded-md border border-cyan-900/60 bg-cyan-950/20 p-3 text-xs text-cyan-100">
+          <p>Preview execution still runs on the local dense CPU simulator until provider adapters are implemented.</p>
+          {isRemoteTarget ? (
+            <p className="mt-2 text-cyan-200/90">
+              Remote targets will submit queue-backed jobs. Results may return much later, so the future execution flow should
+              assume polling, resume, and revisit rather than a live blocking session.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ExecutionJobsPanel.tsx
+++ b/src/components/ExecutionJobsPanel.tsx
@@ -1,0 +1,121 @@
+import type { ExecutionJobRecord } from "../lib/executionJobs";
+
+type ExecutionJobsPanelProps = {
+  jobs: ExecutionJobRecord[];
+  onClearHistory: () => void;
+  onPollJobs: () => void;
+  onRetryJob: (jobId: string) => void;
+};
+
+const formatTimestamp = (value: string): string => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+};
+
+const getStatusClassName = (status: ExecutionJobRecord["status"]): string => {
+  switch (status) {
+    case "completed":
+      return "border-emerald-700 text-emerald-300";
+    case "queued":
+      return "border-amber-700 text-amber-300";
+    case "running":
+      return "border-cyan-700 text-cyan-300";
+    case "failed":
+      return "border-red-700 text-red-300";
+    default:
+      return "border-neutral-700 text-neutral-300";
+  }
+};
+
+export function ExecutionJobsPanel({ jobs, onClearHistory, onPollJobs, onRetryJob }: ExecutionJobsPanelProps): JSX.Element {
+  const hasPollableJobs = jobs.some((job) => job.polling.resumable && (job.status === "queued" || job.status === "running"));
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-neutral-300">Execution Jobs</h2>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onPollJobs}
+            disabled={!hasPollableJobs}
+            className="rounded-md border border-cyan-800 bg-cyan-950/30 px-2 py-1 text-xs text-cyan-200 transition hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:border-neutral-700 disabled:bg-neutral-900 disabled:text-neutral-500"
+          >
+            Poll Jobs
+          </button>
+          <button
+            type="button"
+            onClick={onClearHistory}
+            className="rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-300 transition hover:bg-neutral-800"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-neutral-800 bg-neutral-950/60 p-3">
+        {jobs.length === 0 ? (
+          <p className="text-xs text-neutral-500">
+            No execution jobs yet. Local simulator work and future remote provider work will both appear here.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {jobs.map((job) => (
+              <li key={job.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium text-neutral-100">
+                      {job.targetLabel} · {job.intent}
+                    </p>
+                    <p className="text-xs text-neutral-500">
+                      {job.algorithm.toUpperCase()} · {job.shots} shots · {formatTimestamp(job.submittedAt)}
+                    </p>
+                  </div>
+                  <span className={`rounded-full border px-2 py-1 text-[11px] uppercase tracking-[0.18em] ${getStatusClassName(job.status)}`}>
+                    {job.status}
+                  </span>
+                </div>
+
+                <p className="mt-2 text-xs text-neutral-400">{job.statusDetail}</p>
+
+                <div className="mt-2 flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.18em] text-neutral-500">
+                  <span>Attempts: {job.polling.attemptCount}</span>
+                  <span>Retries: {job.polling.retryCount}</span>
+                  {job.polling.lastAttemptedAt ? <span>Last poll: {formatTimestamp(job.polling.lastAttemptedAt)}</span> : null}
+                  {job.polling.nextSuggestedPollAt ? <span>Next poll: {formatTimestamp(job.polling.nextSuggestedPollAt)}</span> : null}
+                </div>
+
+                {job.result ? (
+                  <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                    <div className="rounded-md border border-neutral-800 bg-neutral-950/70 p-2">
+                      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Estimate</p>
+                      <p className="mt-1 font-mono text-sm text-cyan-300">{job.result.estimate.toFixed(6)}</p>
+                    </div>
+                    <div className="rounded-md border border-neutral-800 bg-neutral-950/70 p-2">
+                      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Total shots used</p>
+                      <p className="mt-1 font-mono text-sm text-neutral-100">{job.result.totalShotsUsed}</p>
+                    </div>
+                  </div>
+                ) : null}
+
+                {job.errorMessage ? <p className="mt-2 text-xs text-red-300">{job.errorMessage}</p> : null}
+                {job.status === "failed" ? (
+                  <div className="mt-3">
+                    <button
+                      type="button"
+                      onClick={() => onRetryJob(job.id)}
+                      className="rounded-md border border-amber-700 bg-amber-950/30 px-2.5 py-1.5 text-xs text-amber-200 transition hover:bg-amber-950/50"
+                    >
+                      Retry Job
+                    </button>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/algorithms.ts
+++ b/src/lib/algorithms.ts
@@ -1,14 +1,99 @@
 import { MOLECULES, type MoleculeKey } from "../data/molecules";
-import { QuantumSimulator } from "./quantumSimulator";
-import { parseAndValidateEdge } from "./utils";
 import type { Algorithm } from "../types";
+import {
+  evaluateCircuitObservables,
+  sampleCircuitBitstrings,
+  type BackendKind,
+  type CircuitOperation,
+  type ExecutableCircuit,
+  type Observable,
+} from "./circuitExecutor";
+import { parseAndValidateEdge } from "./utils";
 
 type QaoaShift =
   | { kind: "gamma"; layer: number; edgeIndex: number; sign: 1 | -1 }
   | { kind: "beta"; layer: number; qubit: number; sign: 1 | -1 };
 
+export type SampledMetricEstimate = {
+  bitstrings: string[];
+  estimatedValue: number;
+  totalShotsUsed: number;
+};
+
 const getValidatedEdgePairs = (nodeCount: number, edges: string[]): Array<[number, number]> =>
   edges.map((edge) => parseAndValidateEdge(edge, nodeCount));
+
+const bitAtQubit = (bitstring: string, qubit: number): 0 | 1 => {
+  const charIndex = bitstring.length - 1 - qubit;
+  const bit = bitstring[charIndex];
+  if (bit !== "0" && bit !== "1") {
+    throw new Error(`Invalid measured bitstring "${bitstring}" for qubit ${qubit}.`);
+  }
+  return bit === "1" ? 1 : 0;
+};
+
+const averageMeasurementEigenvalue = (bitstrings: string[], evaluator: (bitstring: string) => number): number => {
+  if (bitstrings.length === 0) {
+    throw new Error("Cannot estimate an observable from zero shots.");
+  }
+  return bitstrings.reduce((sum, bitstring) => sum + evaluator(bitstring), 0) / bitstrings.length;
+};
+
+const estimateZExpectationFromBitstrings = (bitstrings: string[], qubit: number): number =>
+  averageMeasurementEigenvalue(bitstrings, (bitstring) => (bitAtQubit(bitstring, qubit) === 0 ? 1 : -1));
+
+const estimateZZExpectationFromBitstrings = (bitstrings: string[], q1: number, q2: number): number =>
+  averageMeasurementEigenvalue(bitstrings, (bitstring) => (bitAtQubit(bitstring, q1) === bitAtQubit(bitstring, q2) ? 1 : -1));
+
+export const buildQaoaExecutionCircuit = (
+  nodeCount: number,
+  edges: Array<[number, number]>,
+  gammas: number[],
+  betas: number[],
+  shift?: QaoaShift,
+): ExecutableCircuit => {
+  const operations: CircuitOperation[] = [];
+  const layers = Math.max(gammas.length, betas.length);
+
+  for (let q = 0; q < nodeCount; q += 1) {
+    operations.push({ kind: "ry", qubit: q, theta: Math.PI / 2 });
+  }
+
+  for (let layer = 0; layer < layers; layer += 1) {
+    for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex += 1) {
+      const [q1, q2] = edges[edgeIndex];
+      let gamma = gammas[layer] ?? 0;
+      if (shift?.kind === "gamma" && shift.layer === layer && shift.edgeIndex === edgeIndex) {
+        gamma += shift.sign * (Math.PI / 2);
+      }
+
+      operations.push(
+        { kind: "ry", qubit: q1, theta: Math.PI / 2 },
+        { kind: "ry", qubit: q2, theta: Math.PI / 2 },
+        { kind: "xx", q1, q2, theta: gamma },
+        { kind: "ry", qubit: q1, theta: -Math.PI / 2 },
+        { kind: "ry", qubit: q2, theta: -Math.PI / 2 },
+      );
+    }
+
+    const beta = betas[layer] ?? 0;
+    for (let q = 0; q < nodeCount; q += 1) {
+      let mixerAngle = 2 * beta;
+      if (shift?.kind === "beta" && shift.layer === layer && shift.qubit === q) {
+        mixerAngle += shift.sign * (Math.PI / 2);
+      }
+      operations.push({ kind: "rx", qubit: q, theta: mixerAngle });
+    }
+  }
+
+  return {
+    qubitCount: nodeCount,
+    operations,
+  };
+};
+
+const buildQaoaCostObservables = (edges: Array<[number, number]>): Observable[] =>
+  edges.map(([q1, q2]) => ({ kind: "zz", q1, q2 }));
 
 const evaluateQaoaObjectiveWithSingleGateShift = (
   nodeCount: number,
@@ -16,63 +101,159 @@ const evaluateQaoaObjectiveWithSingleGateShift = (
   gammas: number[],
   betas: number[],
   shift?: QaoaShift,
+  backend: BackendKind = "dense-cpu",
 ): number => {
   if (nodeCount < 1) return 0;
-  const sim = new QuantumSimulator(nodeCount);
+
   const edgePairs = getValidatedEdgePairs(nodeCount, edges);
-  const layers = Math.max(gammas.length, betas.length);
-
-  for (let q = 0; q < nodeCount; q += 1) {
-    sim.applyRy(q, Math.PI / 2);
-  }
-
-  for (let l = 0; l < layers; l += 1) {
-    for (let e = 0; e < edgePairs.length; e += 1) {
-      const [q1, q2] = edgePairs[e];
-      let gamma = gammas[l] ?? 0;
-      if (shift?.kind === "gamma" && shift.layer === l && shift.edgeIndex === e) {
-        gamma += shift.sign * (Math.PI / 2);
-      }
-      sim.applyRy(q1, Math.PI / 2);
-      sim.applyRy(q2, Math.PI / 2);
-      sim.applyXX(q1, q2, gamma);
-      sim.applyRy(q1, -Math.PI / 2);
-      sim.applyRy(q2, -Math.PI / 2);
-    }
-
-    const beta = betas[l] ?? 0;
-    for (let q = 0; q < nodeCount; q += 1) {
-      let mixerAngle = 2 * beta;
-      if (shift?.kind === "beta" && shift.layer === l && shift.qubit === q) {
-        mixerAngle += shift.sign * (Math.PI / 2);
-      }
-      sim.applyRx(q, mixerAngle);
-    }
-  }
-
-  let cost = 0;
-  for (const [q1, q2] of edgePairs) {
-    cost += (1 - sim.expZZ(q1, q2)) / 2;
-  }
+  const circuit = buildQaoaExecutionCircuit(nodeCount, edgePairs, gammas, betas, shift);
+  const observables = buildQaoaCostObservables(edgePairs);
+  const expectationValues = evaluateCircuitObservables(circuit, observables, backend);
+  const cost = expectationValues.reduce((sum, expectation) => sum + (1 - expectation) / 2, 0);
   return -cost;
 };
 
-export const evaluateQaoaCost = (nodeCount: number, edges: string[], gammas: number[], betas: number[]): number => {
-  return -evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas);
+export const evaluateQaoaCost = (
+  nodeCount: number,
+  edges: string[],
+  gammas: number[],
+  betas: number[],
+  backend: BackendKind = "dense-cpu",
+): number => {
+  return -evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas, undefined, backend);
 };
 
-export const evaluateVqeEnergy = (thetas: number[], moleculeKey: MoleculeKey): number => {
-  const sim = new QuantumSimulator(2);
+export const buildVqeExecutionCircuit = (thetas: number[]): ExecutableCircuit => {
+  const operations: CircuitOperation[] = [];
   const layers = Math.floor(thetas.length / 2);
 
-  for (let l = 0; l < layers; l += 1) {
-    sim.applyRy(0, thetas[2 * l] ?? 0);
-    sim.applyRy(1, thetas[2 * l + 1] ?? 0);
-    sim.applyXX(0, 1, Math.PI / 4);
+  for (let layer = 0; layer < layers; layer += 1) {
+    operations.push(
+      { kind: "ry", qubit: 0, theta: thetas[2 * layer] ?? 0 },
+      { kind: "ry", qubit: 1, theta: thetas[2 * layer + 1] ?? 0 },
+      { kind: "xx", q1: 0, q2: 1, theta: Math.PI / 4 },
+    );
   }
 
-  const { g0, g1, g2, g3, g4 } = MOLECULES[moleculeKey].coeffs;
-  return g0 + g1 * sim.expZ(0) + g2 * sim.expZ(1) + g3 * sim.expZZ(0, 1) + g4 * sim.expXX(0, 1);
+  return {
+    qubitCount: 2,
+    operations,
+  };
+};
+
+const VQE_OBSERVABLES: [Observable, Observable, Observable, Observable] = [
+  { kind: "z", qubit: 0 },
+  { kind: "z", qubit: 1 },
+  { kind: "zz", q1: 0, q2: 1 },
+  { kind: "xx", q1: 0, q2: 1 },
+];
+
+export const evaluateVqeEnergy = (
+  thetas: number[],
+  moleculeKey: MoleculeKey,
+  backend: BackendKind = "dense-cpu",
+): number => {
+  const circuit = buildVqeExecutionCircuit(thetas);
+  const {
+    coeffs: { g0, g1, g2, g3, g4 },
+  } = MOLECULES[moleculeKey];
+  const [z0, z1, zz01, xx01] = evaluateCircuitObservables(circuit, VQE_OBSERVABLES, backend);
+
+  return g0 + g1 * z0 + g2 * z1 + g3 * zz01 + g4 * xx01;
+};
+
+export const estimateQaoaCostFromBitstrings = (nodeCount: number, edges: string[], bitstrings: string[]): number => {
+  if (nodeCount < 1) return 0;
+  const edgePairs = getValidatedEdgePairs(nodeCount, edges);
+  if (bitstrings.length === 0 || edgePairs.length === 0) return 0;
+
+  const totalCutSize = bitstrings.reduce(
+    (sum, bitstring) =>
+      sum + edgePairs.reduce((edgeSum, [q1, q2]) => edgeSum + (bitAtQubit(bitstring, q1) !== bitAtQubit(bitstring, q2) ? 1 : 0), 0),
+    0,
+  );
+
+  return totalCutSize / bitstrings.length;
+};
+
+export const estimateVqeEnergyFromMeasurementBitstrings = (
+  moleculeKey: MoleculeKey,
+  zBasisBitstrings: string[],
+  xxBasisBitstrings: string[],
+): number => {
+  const {
+    coeffs: { g0, g1, g2, g3, g4 },
+  } = MOLECULES[moleculeKey];
+  const z0 = estimateZExpectationFromBitstrings(zBasisBitstrings, 0);
+  const z1 = estimateZExpectationFromBitstrings(zBasisBitstrings, 1);
+  const zz01 = estimateZZExpectationFromBitstrings(zBasisBitstrings, 0, 1);
+  const xx01 = estimateZZExpectationFromBitstrings(xxBasisBitstrings, 0, 1);
+
+  return g0 + g1 * z0 + g2 * z1 + g3 * zz01 + g4 * xx01;
+};
+
+export const sampleQaoaBitstrings = (
+  nodeCount: number,
+  edges: string[],
+  gammas: number[],
+  betas: number[],
+  shots: number,
+  backend: BackendKind = "dense-cpu",
+): string[] => {
+  if (nodeCount < 1) return [];
+
+  const edgePairs = getValidatedEdgePairs(nodeCount, edges);
+  const circuit = buildQaoaExecutionCircuit(nodeCount, edgePairs, gammas, betas);
+  return sampleCircuitBitstrings(circuit, shots, backend);
+};
+
+export const sampleQaoaMeasurementEstimate = (
+  nodeCount: number,
+  edges: string[],
+  gammas: number[],
+  betas: number[],
+  shots: number,
+  backend: BackendKind = "dense-cpu",
+): SampledMetricEstimate => {
+  const bitstrings = sampleQaoaBitstrings(nodeCount, edges, gammas, betas, shots, backend);
+  return {
+    bitstrings,
+    estimatedValue: estimateQaoaCostFromBitstrings(nodeCount, edges, bitstrings),
+    totalShotsUsed: bitstrings.length,
+  };
+};
+
+export const sampleVqeBitstrings = (
+  thetas: number[],
+  shots: number,
+  backend: BackendKind = "dense-cpu",
+): string[] => {
+  const circuit = buildVqeExecutionCircuit(thetas);
+  return sampleCircuitBitstrings(circuit, shots, backend);
+};
+
+export const sampleVqeMeasurementEstimate = (
+  thetas: number[],
+  moleculeKey: MoleculeKey,
+  shots: number,
+  backend: BackendKind = "dense-cpu",
+): SampledMetricEstimate => {
+  const zBasisBitstrings = sampleVqeBitstrings(thetas, shots, backend);
+  const xxMeasurementCircuit: ExecutableCircuit = {
+    qubitCount: 2,
+    operations: [
+      ...buildVqeExecutionCircuit(thetas).operations,
+      { kind: "ry", qubit: 0, theta: -Math.PI / 2 },
+      { kind: "ry", qubit: 1, theta: -Math.PI / 2 },
+    ],
+  };
+  const xxBasisBitstrings = sampleCircuitBitstrings(xxMeasurementCircuit, shots, backend);
+
+  return {
+    bitstrings: zBasisBitstrings,
+    estimatedValue: estimateVqeEnergyFromMeasurementBitstrings(moleculeKey, zBasisBitstrings, xxBasisBitstrings),
+    totalShotsUsed: zBasisBitstrings.length + xxBasisBitstrings.length,
+  };
 };
 
 export const evaluateObjectiveFromFlat = (
@@ -101,37 +282,37 @@ export const computeQaoaObjectiveGradients = (
   const gammaGrads = Array.from({ length: layers }, () => 0);
   const betaGrads = Array.from({ length: layers }, () => 0);
 
-  for (let l = 0; l < layers; l += 1) {
-    for (let e = 0; e < edges.length; e += 1) {
+  for (let layer = 0; layer < layers; layer += 1) {
+    for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex += 1) {
       const plus = evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas, {
         kind: "gamma",
-        layer: l,
-        edgeIndex: e,
+        layer,
+        edgeIndex,
         sign: 1,
       });
       const minus = evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas, {
         kind: "gamma",
-        layer: l,
-        edgeIndex: e,
+        layer,
+        edgeIndex,
         sign: -1,
       });
-      gammaGrads[l] += 0.5 * (plus - minus);
+      gammaGrads[layer] += 0.5 * (plus - minus);
     }
 
-    for (let q = 0; q < nodeCount; q += 1) {
+    for (let qubit = 0; qubit < nodeCount; qubit += 1) {
       const plus = evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas, {
         kind: "beta",
-        layer: l,
-        qubit: q,
+        layer,
+        qubit,
         sign: 1,
       });
       const minus = evaluateQaoaObjectiveWithSingleGateShift(nodeCount, edges, gammas, betas, {
         kind: "beta",
-        layer: l,
-        qubit: q,
+        layer,
+        qubit,
         sign: -1,
       });
-      betaGrads[l] += plus - minus;
+      betaGrads[layer] += plus - minus;
     }
   }
 

--- a/src/lib/backendPreferences.ts
+++ b/src/lib/backendPreferences.ts
@@ -1,0 +1,49 @@
+import { getBackendTargetDescriptor, type BackendTargetId } from "./backendTargets";
+
+export type BackendPreferences = {
+  executionTarget: BackendTargetId;
+  ionqApiKey: string;
+};
+
+const BACKEND_PREFERENCES_STORAGE_KEY = "vqa-sim:backend-preferences";
+
+export const DEFAULT_BACKEND_PREFERENCES: BackendPreferences = {
+  executionTarget: "dense-cpu",
+  ionqApiKey: "",
+};
+
+const isValidBackendTargetId = (value: unknown): value is BackendTargetId => {
+  if (typeof value !== "string") return false;
+
+  try {
+    getBackendTargetDescriptor(value as BackendTargetId);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const loadBackendPreferences = (): BackendPreferences => {
+  if (typeof window === "undefined") return DEFAULT_BACKEND_PREFERENCES;
+
+  try {
+    const raw = window.localStorage.getItem(BACKEND_PREFERENCES_STORAGE_KEY);
+    if (!raw) return DEFAULT_BACKEND_PREFERENCES;
+
+    const parsed = JSON.parse(raw) as Partial<BackendPreferences>;
+    return {
+      executionTarget: isValidBackendTargetId(parsed.executionTarget)
+        ? parsed.executionTarget
+        : DEFAULT_BACKEND_PREFERENCES.executionTarget,
+      ionqApiKey: typeof parsed.ionqApiKey === "string" ? parsed.ionqApiKey : DEFAULT_BACKEND_PREFERENCES.ionqApiKey,
+    };
+  } catch {
+    return DEFAULT_BACKEND_PREFERENCES;
+  }
+};
+
+export const saveBackendPreferences = (preferences: BackendPreferences): void => {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.setItem(BACKEND_PREFERENCES_STORAGE_KEY, JSON.stringify(preferences));
+};

--- a/src/lib/backendTargets.test.ts
+++ b/src/lib/backendTargets.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  canBackendTargetAcceptCircuit,
+  getBackendTargetDescriptor,
+  isImplementedBackendTarget,
+  listBackendTargets,
+  planBackendExecution,
+  supportsExecutionIntent,
+} from "./backendTargets";
+
+describe("backendTargets", () => {
+  it("lists implemented and planned backend targets", () => {
+    expect(listBackendTargets().map((target) => target.id)).toEqual(["dense-cpu", "ionq-simulator", "ionq-qpu"]);
+  });
+
+  it("describes the local reference backend", () => {
+    expect(getBackendTargetDescriptor("dense-cpu")).toEqual({
+      id: "dense-cpu",
+      label: "Dense CPU Simulator",
+      provider: "local",
+      implementationStatus: "implemented",
+      executionMode: "local-sync",
+      supportedIntents: ["expectation-values", "shot-sampling", "state-vector"],
+      executorCapabilities: ["ideal-execution", "expectation-values", "shot-sampling", "state-vector"],
+      requiresProviderAdapter: false,
+      notes: "Reference in-process backend used for exact evaluation, sampling, and state-vector inspection.",
+    });
+  });
+
+  it("marks IonQ targets as planned remote backends", () => {
+    const ionqQpu = getBackendTargetDescriptor("ionq-qpu");
+
+    expect(ionqQpu.provider).toBe("ionq");
+    expect(ionqQpu.implementationStatus).toBe("planned");
+    expect(ionqQpu.executionMode).toBe("remote-job");
+    expect(ionqQpu.requiresProviderAdapter).toBe(true);
+  });
+
+  it("distinguishes implemented executor targets from planned provider targets", () => {
+    expect(isImplementedBackendTarget("dense-cpu")).toBe(true);
+    expect(isImplementedBackendTarget("ionq-simulator")).toBe(false);
+    expect(isImplementedBackendTarget("ionq-qpu")).toBe(false);
+  });
+
+  it("tracks execution-intent support per target", () => {
+    expect(supportsExecutionIntent("dense-cpu", "expectation-values")).toBe(true);
+    expect(supportsExecutionIntent("dense-cpu", "state-vector")).toBe(true);
+    expect(supportsExecutionIntent("ionq-simulator", "shot-sampling")).toBe(true);
+    expect(supportsExecutionIntent("ionq-simulator", "expectation-values")).toBe(false);
+    expect(supportsExecutionIntent("ionq-qpu", "state-vector")).toBe(false);
+  });
+
+  it("plans local execution for implemented simulator work", () => {
+    expect(planBackendExecution("dense-cpu", "expectation-values")).toEqual({
+      kind: "local-executor",
+      backend: "dense-cpu",
+      intent: "expectation-values",
+    });
+  });
+
+  it("plans remote job execution for IonQ targets", () => {
+    expect(planBackendExecution("ionq-qpu", "shot-sampling")).toEqual({
+      kind: "remote-job",
+      target: "ionq-qpu",
+      provider: "ionq",
+      intent: "shot-sampling",
+      requiresProviderAdapter: true,
+    });
+  });
+
+  it("rejects unsupported intents for remote provider targets", () => {
+    expect(() => planBackendExecution("ionq-qpu", "state-vector")).toThrow(/does not support execution intent/i);
+  });
+
+  it("flags when a target needs provider-specific transpilation", () => {
+    expect(
+      canBackendTargetAcceptCircuit("ionq-simulator", {
+        qubitCount: 2,
+        operations: [{ kind: "xx", q1: 0, q2: 1, theta: Math.PI / 4 }],
+      }),
+    ).toEqual({
+      supported: true,
+      reason: "Execution requires provider-specific transpilation and remote job submission.",
+    });
+  });
+
+  it("rejects empty circuits at the target-planning layer", () => {
+    expect(
+      canBackendTargetAcceptCircuit("dense-cpu", {
+        qubitCount: 0,
+        operations: [],
+      }),
+    ).toEqual({
+      supported: false,
+      reason: "Backend targets expect at least one qubit in the executable circuit.",
+    });
+  });
+});

--- a/src/lib/backendTargets.ts
+++ b/src/lib/backendTargets.ts
@@ -1,0 +1,139 @@
+import type { BackendKind, ExecutableCircuit, ExecutorCapability } from "./circuitExecutor";
+
+export type BackendProvider = "local" | "ionq";
+
+export type BackendTargetId = BackendKind | "ionq-simulator" | "ionq-qpu";
+
+export type BackendImplementationStatus = "implemented" | "planned";
+
+export type BackendExecutionMode = "local-sync" | "remote-job";
+
+export type BackendExecutionIntent = "expectation-values" | "shot-sampling" | "state-vector";
+
+export type BackendTargetDescriptor = {
+  id: BackendTargetId;
+  label: string;
+  provider: BackendProvider;
+  implementationStatus: BackendImplementationStatus;
+  executionMode: BackendExecutionMode;
+  supportedIntents: readonly BackendExecutionIntent[];
+  executorCapabilities: readonly ExecutorCapability[];
+  requiresProviderAdapter: boolean;
+  notes: string;
+};
+
+export type BackendExecutionPlan =
+  | {
+      kind: "local-executor";
+      backend: BackendKind;
+      intent: BackendExecutionIntent;
+    }
+  | {
+      kind: "remote-job";
+      target: Exclude<BackendTargetId, BackendKind>;
+      provider: Exclude<BackendProvider, "local">;
+      intent: BackendExecutionIntent;
+      requiresProviderAdapter: true;
+    };
+
+const BACKEND_TARGETS: readonly BackendTargetDescriptor[] = [
+  {
+    id: "dense-cpu",
+    label: "Dense CPU Simulator",
+    provider: "local",
+    implementationStatus: "implemented",
+    executionMode: "local-sync",
+    supportedIntents: ["expectation-values", "shot-sampling", "state-vector"],
+    executorCapabilities: ["ideal-execution", "expectation-values", "shot-sampling", "state-vector"],
+    requiresProviderAdapter: false,
+    notes: "Reference in-process backend used for exact evaluation, sampling, and state-vector inspection.",
+  },
+  {
+    id: "ionq-simulator",
+    label: "IonQ Simulator",
+    provider: "ionq",
+    implementationStatus: "planned",
+    executionMode: "remote-job",
+    supportedIntents: ["shot-sampling"],
+    executorCapabilities: [],
+    requiresProviderAdapter: true,
+    notes: "Planned remote provider target. Requests should flow through a provider adapter and async job lifecycle.",
+  },
+  {
+    id: "ionq-qpu",
+    label: "IonQ QPU",
+    provider: "ionq",
+    implementationStatus: "planned",
+    executionMode: "remote-job",
+    supportedIntents: ["shot-sampling"],
+    executorCapabilities: [],
+    requiresProviderAdapter: true,
+    notes: "Planned hardware target. Keep the abstraction shot-based and job-oriented rather than state-vector oriented.",
+  },
+] as const;
+
+export const listBackendTargets = (): readonly BackendTargetDescriptor[] => BACKEND_TARGETS;
+
+export const getBackendTargetDescriptor = (targetId: BackendTargetId): BackendTargetDescriptor => {
+  const descriptor = BACKEND_TARGETS.find((target) => target.id === targetId);
+  if (!descriptor) {
+    throw new Error(`Unknown backend target "${targetId}".`);
+  }
+  return descriptor;
+};
+
+export const isImplementedBackendTarget = (targetId: BackendTargetId): targetId is BackendKind =>
+  getBackendTargetDescriptor(targetId).implementationStatus === "implemented";
+
+export const supportsExecutionIntent = (targetId: BackendTargetId, intent: BackendExecutionIntent): boolean =>
+  getBackendTargetDescriptor(targetId).supportedIntents.includes(intent);
+
+export const canBackendTargetAcceptCircuit = (
+  targetId: BackendTargetId,
+  circuit: ExecutableCircuit,
+): { supported: boolean; reason?: string } => {
+  const descriptor = getBackendTargetDescriptor(targetId);
+
+  if (circuit.qubitCount < 1) {
+    return {
+      supported: false,
+      reason: "Backend targets expect at least one qubit in the executable circuit.",
+    };
+  }
+
+  if (descriptor.requiresProviderAdapter) {
+    return {
+      supported: true,
+      reason: "Execution requires provider-specific transpilation and remote job submission.",
+    };
+  }
+
+  return { supported: true };
+};
+
+export const planBackendExecution = (
+  targetId: BackendTargetId,
+  intent: BackendExecutionIntent,
+): BackendExecutionPlan => {
+  const descriptor = getBackendTargetDescriptor(targetId);
+
+  if (!supportsExecutionIntent(targetId, intent)) {
+    throw new Error(`Backend target "${targetId}" does not support execution intent "${intent}".`);
+  }
+
+  if (descriptor.executionMode === "local-sync") {
+    return {
+      kind: "local-executor",
+      backend: targetId as BackendKind,
+      intent,
+    };
+  }
+
+  return {
+    kind: "remote-job",
+    target: targetId as Exclude<BackendTargetId, BackendKind>,
+    provider: descriptor.provider as Exclude<BackendProvider, "local">,
+    intent,
+    requiresProviderAdapter: true,
+  };
+};

--- a/src/lib/circuitExecutor.test.ts
+++ b/src/lib/circuitExecutor.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  estimateQaoaCostFromBitstrings,
+  estimateVqeEnergyFromMeasurementBitstrings,
+  sampleQaoaBitstrings,
+  sampleQaoaMeasurementEstimate,
+  sampleVqeBitstrings,
+  sampleVqeMeasurementEstimate,
+} from "./algorithms";
+import {
+  denseCpuCircuitExecutor,
+  evaluateCircuitObservables,
+  executeCircuit,
+  getCircuitStateVector,
+  getCircuitExecutor,
+  sampleCircuitBitstrings,
+  supportsCapability,
+  type ExecutableCircuit,
+} from "./circuitExecutor";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DenseCpuCircuitExecutor", () => {
+  it("exposes backend metadata and capabilities", () => {
+    expect(denseCpuCircuitExecutor.backend).toBe("dense-cpu");
+    expect(denseCpuCircuitExecutor.capabilities).toEqual([
+      "ideal-execution",
+      "expectation-values",
+      "shot-sampling",
+      "state-vector",
+    ]);
+    expect(supportsCapability(denseCpuCircuitExecutor, "ideal-execution")).toBe(true);
+    expect(supportsCapability(denseCpuCircuitExecutor, "expectation-values")).toBe(true);
+    expect(supportsCapability(denseCpuCircuitExecutor, "shot-sampling")).toBe(true);
+    expect(supportsCapability(denseCpuCircuitExecutor, "state-vector")).toBe(true);
+    expect(getCircuitExecutor("dense-cpu")).toBe(denseCpuCircuitExecutor);
+  });
+
+  it("executes circuits through the backend-agnostic entrypoint", () => {
+    const result = executeCircuit({
+      circuit: {
+        qubitCount: 1,
+        operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+      },
+      observables: [{ kind: "z", qubit: 0 }],
+      measurement: { kind: "all-qubits", shots: 2 },
+    });
+
+    expect(result.backend).toBe("dense-cpu");
+    expect(result.expectationValues?.kind).toBe("expectation-values");
+    expect(result.expectationValues?.values[0]).toBeCloseTo(-1, 12);
+    expect(result.measurement?.kind).toBe("all-qubits");
+    expect(result.measurement?.shots).toBe(2);
+    expect(result.measurement?.bitstrings).toEqual(["1", "1"]);
+  });
+
+  it("evaluates observables for a compiled circuit", () => {
+    const result = denseCpuCircuitExecutor.execute({
+      circuit: {
+        qubitCount: 2,
+        operations: [
+          { kind: "rx", qubit: 0, theta: Math.PI },
+          { kind: "ry", qubit: 1, theta: Math.PI / 2 },
+        ],
+      },
+      observables: [
+        { kind: "z", qubit: 0 },
+        { kind: "z", qubit: 1 },
+        { kind: "zz", q1: 0, q2: 1 },
+      ],
+    });
+
+    expect(result.backend).toBe("dense-cpu");
+    expect(result.expectationValues?.observables).toEqual([
+      { kind: "z", qubit: 0 },
+      { kind: "z", qubit: 1 },
+      { kind: "zz", q1: 0, q2: 1 },
+    ]);
+    expect(result.expectationValues?.values[0]).toBeCloseTo(-1, 12);
+    expect(result.expectationValues?.values[1]).toBeCloseTo(0, 12);
+    expect(result.expectationValues?.values[2]).toBeCloseTo(0, 12);
+  });
+
+  it("samples all-qubit measurements for deterministic basis states", () => {
+    const result = denseCpuCircuitExecutor.execute({
+      circuit: {
+        qubitCount: 2,
+        operations: [
+          { kind: "rx", qubit: 0, theta: Math.PI },
+          { kind: "rx", qubit: 1, theta: Math.PI },
+        ],
+      },
+      measurement: {
+        kind: "all-qubits",
+        shots: 3,
+      },
+    });
+
+    expect(result.measurement?.kind).toBe("all-qubits");
+    expect(result.measurement?.shots).toBe(3);
+    expect(result.measurement?.bitstrings).toEqual(["11", "11", "11"]);
+  });
+
+  it("accepts an explicit ideal noise model", () => {
+    const result = denseCpuCircuitExecutor.execute({
+      circuit: {
+        qubitCount: 1,
+        operations: [{ kind: "ry", qubit: 0, theta: Math.PI / 2 }],
+      },
+      observables: [{ kind: "z", qubit: 0 }],
+      noiseModel: { kind: "ideal" },
+    });
+
+    expect(result.expectationValues?.values[0]).toBeCloseTo(0, 12);
+  });
+
+  it("returns a final state vector when explicitly requested", () => {
+    const result = executeCircuit({
+      circuit: {
+        qubitCount: 1,
+        operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+      },
+      stateVector: { kind: "final-state-vector" },
+    });
+
+    expect(result.stateVector?.kind).toBe("final-state-vector");
+    expect(result.stateVector?.amplitudes).toHaveLength(2);
+    expect(result.stateVector?.amplitudes[0]?.re).toBeCloseTo(0, 12);
+    expect(result.stateVector?.amplitudes[0]?.im).toBeCloseTo(0, 12);
+    expect(result.stateVector?.amplitudes[1]?.re).toBeCloseTo(0, 12);
+    expect(result.stateVector?.amplitudes[1]?.im).toBeCloseTo(-1, 12);
+  });
+
+  it("rejects unsupported noisy execution requests", () => {
+    expect(() =>
+      denseCpuCircuitExecutor.execute({
+        circuit: {
+          qubitCount: 1,
+          operations: [],
+        },
+        noiseModel: {
+          kind: "depolarizing",
+          probability: 0.05,
+        },
+      }),
+    ).toThrow(/unsupported noise model/i);
+  });
+
+  it("rejects invalid depolarizing probabilities", () => {
+    expect(() =>
+      denseCpuCircuitExecutor.execute({
+        circuit: {
+          qubitCount: 1,
+          operations: [],
+        },
+        noiseModel: {
+          kind: "depolarizing",
+          probability: 1.5,
+        },
+      }),
+    ).toThrow(/invalid depolarizing probability/i);
+  });
+
+  it("rejects out-of-range circuit operations before execution", () => {
+    expect(() =>
+      executeCircuit({
+        circuit: {
+          qubitCount: 1,
+          operations: [{ kind: "rx", qubit: 1, theta: 0.25 }],
+        },
+      }),
+    ).toThrow(/invalid qubit index/i);
+  });
+
+  it("rejects self-paired xx operations", () => {
+    expect(() =>
+      executeCircuit({
+        circuit: {
+          qubitCount: 2,
+          operations: [{ kind: "xx", q1: 0, q2: 0, theta: Math.PI / 4 }],
+        },
+      }),
+    ).toThrow(/expected two distinct qubits/i);
+  });
+
+  it("rejects non-finite rotation parameters", () => {
+    expect(() =>
+      executeCircuit({
+        circuit: {
+          qubitCount: 1,
+          operations: [{ kind: "ry", qubit: 0, theta: Number.NaN }],
+        },
+      }),
+    ).toThrow(/finite rotation angle/i);
+  });
+});
+
+describe("sampleCircuitBitstrings", () => {
+  const equalSuperpositionCircuit: ExecutableCircuit = {
+    qubitCount: 2,
+    operations: [
+      { kind: "ry", qubit: 0, theta: Math.PI / 2 },
+      { kind: "ry", qubit: 1, theta: Math.PI / 2 },
+    ],
+  };
+
+  it("returns sampled basis states in cumulative probability order", () => {
+    const samples = [0.1, 0.3, 0.6, 0.9];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.1);
+
+    expect(sampleCircuitBitstrings(equalSuperpositionCircuit, 4)).toEqual(["00", "01", "10", "11"]);
+  });
+
+  it("rejects invalid shot counts", () => {
+    expect(() => sampleCircuitBitstrings(equalSuperpositionCircuit, 0)).toThrow(/invalid shot count/i);
+  });
+
+  it("evaluates observables through the capability-specific helper", () => {
+    expect(
+      evaluateCircuitObservables(
+        {
+          qubitCount: 1,
+          operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+        },
+        [{ kind: "z", qubit: 0 }],
+      ),
+    ).toEqual([-1]);
+  });
+
+  it("returns a copied state vector through the state helper", () => {
+    const amplitudes = getCircuitStateVector({
+      qubitCount: 1,
+      operations: [{ kind: "ry", qubit: 0, theta: Math.PI / 2 }],
+    });
+
+    expect(amplitudes).toHaveLength(2);
+    expect(amplitudes[0]?.re).toBeCloseTo(Math.SQRT1_2, 12);
+    expect(amplitudes[0]?.im).toBeCloseTo(0, 12);
+    expect(amplitudes[1]?.re).toBeCloseTo(Math.SQRT1_2, 12);
+    expect(amplitudes[1]?.im).toBeCloseTo(0, 12);
+  });
+});
+
+describe("shot-based algorithm helpers", () => {
+  it("samples QAOA bitstrings through the execution helper", () => {
+    const samples = [0.1, 0.3, 0.6, 0.9];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.1);
+
+    expect(sampleQaoaBitstrings(2, [], [], [], 4)).toEqual(["00", "01", "10", "11"]);
+  });
+
+  it("estimates QAOA cut values from measured bitstrings", () => {
+    expect(estimateQaoaCostFromBitstrings(2, ["0-1"], ["00", "01", "11", "10"])).toBeCloseTo(0.5, 12);
+
+    const samples = [0.1, 0.3, 0.6, 0.9];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.1);
+
+    expect(sampleQaoaMeasurementEstimate(2, ["0-1"], [], [], 4)).toEqual({
+      bitstrings: ["00", "01", "10", "11"],
+      estimatedValue: 0.5,
+      totalShotsUsed: 4,
+    });
+  });
+
+  it("samples VQE bitstrings through the execution helper", () => {
+    expect(sampleVqeBitstrings([], 3)).toEqual(["00", "00", "00"]);
+  });
+
+  it("estimates VQE energy from basis-sampled observables", () => {
+    expect(estimateVqeEnergyFromMeasurementBitstrings("H2_0.74", ["00", "01", "11", "10"], ["00", "11"]))
+      .toBeCloseTo(-0.871442, 6);
+  });
+
+  it("returns both histogram samples and sampled VQE estimates", () => {
+    const samples = [0.1, 0.1, 0.1, 0.9];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.1);
+
+    expect(sampleVqeMeasurementEstimate([], "H2_0.74", 2)).toEqual({
+      bitstrings: ["00", "00"],
+      estimatedValue: -0.8827221,
+      totalShotsUsed: 4,
+    });
+  });
+});

--- a/src/lib/circuitExecutor.ts
+++ b/src/lib/circuitExecutor.ts
@@ -1,0 +1,350 @@
+import { QuantumSimulator, type ComplexAmplitude } from "./quantumSimulator";
+
+export type BackendKind = "dense-cpu";
+
+export type ExecutorCapability = "ideal-execution" | "expectation-values" | "shot-sampling" | "state-vector";
+
+export type CircuitOperation =
+  | { kind: "rx"; qubit: number; theta: number }
+  | { kind: "ry"; qubit: number; theta: number }
+  | { kind: "xx"; q1: number; q2: number; theta: number };
+
+export type ExecutableCircuit = {
+  qubitCount: number;
+  operations: CircuitOperation[];
+};
+
+export type Observable =
+  | { kind: "z"; qubit: number }
+  | { kind: "zz"; q1: number; q2: number }
+  | { kind: "xx"; q1: number; q2: number };
+
+export type MeasurementRequest = {
+  kind: "all-qubits";
+  shots: number;
+};
+
+export type StateVectorRequest = {
+  kind: "final-state-vector";
+};
+
+export type NoiseModel =
+  | { kind: "ideal" }
+  | {
+      kind: "depolarizing";
+      probability: number;
+    };
+
+export type ExecutionRequest = {
+  backend?: BackendKind;
+  circuit: ExecutableCircuit;
+  observables?: Observable[];
+  measurement?: MeasurementRequest;
+  stateVector?: StateVectorRequest;
+  noiseModel?: NoiseModel;
+};
+
+export type MeasurementResult = {
+  kind: "all-qubits";
+  shots: number;
+  bitstrings: string[];
+};
+
+export type ExpectationValuesResult = {
+  kind: "expectation-values";
+  observables: Observable[];
+  values: number[];
+};
+
+export type StateVectorResult = {
+  kind: "final-state-vector";
+  amplitudes: ComplexAmplitude[];
+};
+
+export type ExecutionResult = {
+  backend: BackendKind;
+  expectationValues?: ExpectationValuesResult;
+  measurement?: MeasurementResult;
+  stateVector?: StateVectorResult;
+};
+
+export interface CircuitExecutor {
+  readonly backend: BackendKind;
+  readonly capabilities: readonly ExecutorCapability[];
+  execute(request: ExecutionRequest): ExecutionResult;
+}
+
+export const supportsCapability = (
+  executor: Pick<CircuitExecutor, "capabilities">,
+  capability: ExecutorCapability,
+): boolean => executor.capabilities.includes(capability);
+
+const assertValidShotCount = (shots: number): void => {
+  if (!Number.isInteger(shots) || shots < 1) {
+    throw new Error(`Invalid shot count ${shots}; expected a positive integer.`);
+  }
+};
+
+const assertValidQubitIndex = (qubit: number, qubitCount: number, label: string): void => {
+  if (!Number.isInteger(qubit) || qubit < 0 || qubit >= qubitCount) {
+    throw new Error(`Invalid ${label} ${qubit}; expected an integer in [0, ${Math.max(qubitCount - 1, 0)}].`);
+  }
+};
+
+const assertFiniteRotation = (theta: number, label: string): void => {
+  if (!Number.isFinite(theta)) {
+    throw new Error(`Invalid ${label} ${theta}; expected a finite rotation angle.`);
+  }
+};
+
+const assertValidCircuit = (circuit: ExecutableCircuit): void => {
+  if (!Number.isInteger(circuit.qubitCount) || circuit.qubitCount < 0) {
+    throw new Error(`Invalid qubit count ${circuit.qubitCount}; expected a non-negative integer.`);
+  }
+
+  for (const operation of circuit.operations) {
+    switch (operation.kind) {
+      case "rx":
+        assertValidQubitIndex(operation.qubit, circuit.qubitCount, "qubit index");
+        assertFiniteRotation(operation.theta, "rx theta");
+        break;
+      case "ry":
+        assertValidQubitIndex(operation.qubit, circuit.qubitCount, "qubit index");
+        assertFiniteRotation(operation.theta, "ry theta");
+        break;
+      case "xx":
+        assertValidQubitIndex(operation.q1, circuit.qubitCount, "q1 index");
+        assertValidQubitIndex(operation.q2, circuit.qubitCount, "q2 index");
+        if (operation.q1 === operation.q2) {
+          throw new Error(`Invalid xx operation on qubit ${operation.q1}; expected two distinct qubits.`);
+        }
+        assertFiniteRotation(operation.theta, "xx theta");
+        break;
+      default: {
+        const exhaustiveCheck: never = operation;
+        throw new Error(`Unsupported operation ${(exhaustiveCheck as { kind?: string }).kind ?? "unknown"}.`);
+      }
+    }
+  }
+};
+
+const assertCapabilitySupport = (executor: CircuitExecutor, capability: ExecutorCapability): void => {
+  if (!supportsCapability(executor, capability)) {
+    throw new Error(`Backend "${executor.backend}" does not support executor capability "${capability}".`);
+  }
+};
+
+const assertValidExecutionRequest = (
+  executor: CircuitExecutor,
+  { circuit, observables = [], measurement, stateVector }: ExecutionRequest,
+): void => {
+  assertValidCircuit(circuit);
+
+  if (observables.length > 0) {
+    assertCapabilitySupport(executor, "expectation-values");
+  }
+
+  if (stateVector) {
+    assertValidStateVectorRequest(stateVector);
+  }
+
+  if (!measurement) return;
+
+  assertCapabilitySupport(executor, "shot-sampling");
+
+  if (measurement.kind === "all-qubits") {
+    assertValidShotCount(measurement.shots);
+    return;
+  }
+
+  throw new Error(`Unsupported measurement kind ${(measurement as { kind?: string }).kind ?? "unknown"}.`);
+};
+
+const assertValidStateVectorRequest = (stateVector?: StateVectorRequest): void => {
+  if (!stateVector) return;
+  if (stateVector.kind === "final-state-vector") return;
+  throw new Error(`Unsupported state-vector request kind ${(stateVector as { kind?: string }).kind ?? "unknown"}.`);
+};
+
+const assertSupportedNoiseModel = (noiseModel?: NoiseModel): void => {
+  if (!noiseModel || noiseModel.kind === "ideal") return;
+
+  if (!Number.isFinite(noiseModel.probability) || noiseModel.probability < 0 || noiseModel.probability > 1) {
+    throw new Error(
+      `Invalid depolarizing probability ${noiseModel.probability}; expected a finite value between 0 and 1.`,
+    );
+  }
+
+  throw new Error(
+    `Unsupported noise model "${noiseModel.kind}" for backend "dense-cpu"; only ideal execution is currently implemented.`,
+  );
+};
+
+const probabilityOfIndex = (sim: QuantumSimulator, index: number): number => {
+  const amplitude = sim.state[index];
+  return amplitude.re * amplitude.re + amplitude.im * amplitude.im;
+};
+
+const sampleAllQubits = (sim: QuantumSimulator, shots: number): string[] => {
+  assertValidShotCount(shots);
+
+  const cumulativeProbabilities: number[] = [];
+  let total = 0;
+
+  for (let i = 0; i < sim.dim; i += 1) {
+    total += probabilityOfIndex(sim, i);
+    cumulativeProbabilities.push(total);
+  }
+
+  if (Math.abs(total - 1) > 1e-9) {
+    throw new Error(`State vector probabilities do not sum to 1 within tolerance; got ${total}.`);
+  }
+
+  return Array.from({ length: shots }, () => {
+    const sample = Math.random();
+    const sampledIndex = cumulativeProbabilities.findIndex((value) => sample <= value);
+    const index = sampledIndex === -1 ? sim.dim - 1 : sampledIndex;
+    return index.toString(2).padStart(sim.nQubits, "0");
+  });
+};
+
+const evaluateObservable = (sim: QuantumSimulator, observable: Observable): number => {
+  switch (observable.kind) {
+    case "z":
+      return sim.expZ(observable.qubit);
+    case "zz":
+      return sim.expZZ(observable.q1, observable.q2);
+    case "xx":
+      return sim.expXX(observable.q1, observable.q2);
+    default: {
+      const exhaustiveCheck: never = observable;
+      return exhaustiveCheck;
+    }
+  }
+};
+
+export class DenseCpuCircuitExecutor implements CircuitExecutor {
+  readonly backend = "dense-cpu" as const;
+  readonly capabilities = ["ideal-execution", "expectation-values", "shot-sampling", "state-vector"] as const;
+
+  execute({
+    backend = this.backend,
+    circuit,
+    observables = [],
+    measurement,
+    stateVector,
+    noiseModel,
+  }: ExecutionRequest): ExecutionResult {
+    if (backend !== this.backend) {
+      throw new Error(`Unsupported backend \"${backend}\"; only \"dense-cpu\" is currently implemented.`);
+    }
+
+    assertSupportedNoiseModel(noiseModel);
+    assertValidStateVectorRequest(stateVector);
+
+    const sim = new QuantumSimulator(circuit.qubitCount);
+
+    for (const operation of circuit.operations) {
+      switch (operation.kind) {
+        case "rx":
+          sim.applyRx(operation.qubit, operation.theta);
+          break;
+        case "ry":
+          sim.applyRy(operation.qubit, operation.theta);
+          break;
+        case "xx":
+          sim.applyXX(operation.q1, operation.q2, operation.theta);
+          break;
+        default: {
+          const exhaustiveCheck: never = operation;
+          throw new Error(`Unsupported operation ${(exhaustiveCheck as { kind?: string }).kind ?? "unknown"}.`);
+        }
+      }
+    }
+
+    return {
+      backend,
+      expectationValues:
+        observables.length > 0
+          ? {
+              kind: "expectation-values",
+              observables,
+              values: observables.map((observable) => evaluateObservable(sim, observable)),
+            }
+          : undefined,
+      measurement:
+        measurement?.kind === "all-qubits"
+          ? {
+              kind: "all-qubits",
+              shots: measurement.shots,
+              bitstrings: sampleAllQubits(sim, measurement.shots),
+            }
+          : undefined,
+      stateVector:
+        stateVector?.kind === "final-state-vector"
+          ? {
+              kind: "final-state-vector",
+              amplitudes: sim.state.map((amplitude) => ({ re: amplitude.re, im: amplitude.im })),
+            }
+          : undefined,
+    };
+  }
+}
+
+export const denseCpuCircuitExecutor = new DenseCpuCircuitExecutor();
+
+export const getCircuitExecutor = (backend: BackendKind): CircuitExecutor => {
+  switch (backend) {
+    case "dense-cpu":
+      return denseCpuCircuitExecutor;
+    default: {
+      const exhaustiveCheck: never = backend;
+      throw new Error(`Unsupported backend \"${exhaustiveCheck}\".`);
+    }
+  }
+};
+
+export const executeCircuit = (request: ExecutionRequest): ExecutionResult => {
+  const backend = request.backend ?? "dense-cpu";
+  const executor = getCircuitExecutor(backend);
+  const normalizedRequest = { ...request, backend };
+
+  assertValidExecutionRequest(executor, normalizedRequest);
+  if (normalizedRequest.stateVector) {
+    assertCapabilitySupport(executor, "state-vector");
+  }
+  return executor.execute(normalizedRequest);
+};
+
+export const evaluateCircuitObservables = (
+  circuit: ExecutableCircuit,
+  observables: Observable[],
+  backend: BackendKind = "dense-cpu",
+): number[] => executeCircuit({ backend, circuit, observables }).expectationValues?.values ?? [];
+
+export const sampleCircuitBitstrings = (
+  circuit: ExecutableCircuit,
+  shots: number,
+  backend: BackendKind = "dense-cpu",
+): string[] => {
+  const result = executeCircuit({
+    backend,
+    circuit,
+    measurement: { kind: "all-qubits", shots },
+  });
+
+  return result.measurement?.bitstrings ?? [];
+};
+
+export const getCircuitStateVector = (
+  circuit: ExecutableCircuit,
+  backend: BackendKind = "dense-cpu",
+): ComplexAmplitude[] => {
+  const result = executeCircuit({
+    backend,
+    circuit,
+    stateVector: { kind: "final-state-vector" },
+  });
+
+  return result.stateVector?.amplitudes ?? [];
+};

--- a/src/lib/executionJobs.test.ts
+++ b/src/lib/executionJobs.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { buildQaoaExecutionCircuit, buildVqeExecutionCircuit } from "./algorithms";
+import {
+  loadExecutionJobs,
+  markExecutionJobFailed,
+  pollExecutionJobs,
+  retryExecutionJob,
+  saveExecutionJobs,
+  submitSamplingExecutionJob,
+} from "./executionJobs";
+
+describe("executionJobs", () => {
+  it("completes local dense-cpu sampling jobs immediately", () => {
+    const circuit = buildQaoaExecutionCircuit(2, [[0, 1]], [], []);
+    const job = submitSamplingExecutionJob({
+      targetId: "dense-cpu",
+      circuit,
+      algorithm: "qaoa",
+      shots: 4,
+      nodeCount: 2,
+      edges: ["0-1"],
+      gammas: [],
+      betas: [],
+    });
+
+    expect(job.status).toBe("completed");
+    expect(job.queueBehavior).toBe("instant");
+    expect(job.result?.bitstrings).toHaveLength(4);
+    expect(job.statusDetail).toMatch(/completed immediately/i);
+  });
+
+  it("queues remote provider jobs instead of pretending to execute them locally", () => {
+    const circuit = buildVqeExecutionCircuit([]);
+    const job = submitSamplingExecutionJob({
+      targetId: "ionq-simulator",
+      circuit,
+      algorithm: "vqe",
+      shots: 32,
+      thetas: [],
+      molecule: "H2_0.74",
+    });
+
+    expect(job.status).toBe("queued");
+    expect(job.queueBehavior).toBe("provider-queue");
+    expect(job.result).toBeUndefined();
+    expect(job.statusDetail).toMatch(/queued remote target/i);
+    expect(job.polling.attemptCount).toBe(0);
+    expect(job.polling.resumable).toBe(true);
+  });
+
+  it("persists and restores execution job history", () => {
+    const jobs = [
+      {
+        id: "job_test",
+        targetId: "dense-cpu" as const,
+        targetLabel: "Dense CPU Simulator",
+        algorithm: "qaoa" as const,
+        intent: "shot-sampling" as const,
+        status: "completed" as const,
+        submittedAt: "2026-04-02T00:00:00.000Z",
+        updatedAt: "2026-04-02T00:00:00.000Z",
+        startedAt: "2026-04-02T00:00:00.000Z",
+        completedAt: "2026-04-02T00:00:00.000Z",
+        shots: 64,
+        queueBehavior: "instant" as const,
+        statusDetail: "Completed immediately on Dense CPU Simulator.",
+        polling: {
+          attemptCount: 0,
+          retryCount: 0,
+          resumable: false,
+        },
+      },
+    ];
+
+    saveExecutionJobs(jobs);
+    expect(loadExecutionJobs()).toEqual(jobs);
+  });
+
+  it("normalizes older persisted jobs that did not include polling metadata", () => {
+    window.localStorage.setItem(
+      "vqa-sim:execution-jobs",
+      JSON.stringify([
+        {
+          id: "legacy_job",
+          targetId: "ionq-simulator",
+          targetLabel: "IonQ Simulator",
+          algorithm: "qaoa",
+          intent: "shot-sampling",
+          status: "queued",
+          submittedAt: "2026-04-02T00:00:00.000Z",
+          updatedAt: "2026-04-02T00:00:00.000Z",
+          shots: 128,
+          queueBehavior: "provider-queue",
+          statusDetail: "Legacy queued job",
+        },
+      ]),
+    );
+
+    expect(loadExecutionJobs()[0]?.polling).toEqual({
+      attemptCount: 0,
+      retryCount: 0,
+      resumable: true,
+      nextSuggestedPollAt: "2026-04-02T00:15:00.000Z",
+    });
+  });
+
+  it("advances resumable remote jobs from queued to running when polled", () => {
+    const circuit = buildVqeExecutionCircuit([]);
+    const queuedJob = submitSamplingExecutionJob({
+      targetId: "ionq-qpu",
+      circuit,
+      algorithm: "vqe",
+      shots: 32,
+      thetas: [],
+      molecule: "H2_0.74",
+    });
+
+    const [runningJob] = pollExecutionJobs([queuedJob], "2026-04-02T12:00:00.000Z");
+
+    expect(runningJob?.status).toBe("running");
+    expect(runningJob?.polling.attemptCount).toBe(1);
+    expect(runningJob?.polling.lastAttemptedAt).toBe("2026-04-02T12:00:00.000Z");
+    expect(runningJob?.polling.externalJobId).toMatch(/^remote_/);
+  });
+
+  it("can mark running jobs as failed and retry them", () => {
+    const circuit = buildVqeExecutionCircuit([]);
+    const queuedJob = submitSamplingExecutionJob({
+      targetId: "ionq-simulator",
+      circuit,
+      algorithm: "vqe",
+      shots: 16,
+      thetas: [],
+      molecule: "H2_0.74",
+    });
+
+    const [runningJob] = pollExecutionJobs([queuedJob], "2026-04-02T12:00:00.000Z");
+    const failedJob = markExecutionJobFailed(runningJob!, "Provider timeout", "2026-04-02T13:00:00.000Z");
+    const retriedJob = retryExecutionJob(failedJob, "2026-04-02T14:00:00.000Z");
+
+    expect(failedJob.status).toBe("failed");
+    expect(failedJob.errorMessage).toBe("Provider timeout");
+    expect(retriedJob.status).toBe("queued");
+    expect(retriedJob.polling.retryCount).toBe(1);
+    expect(retriedJob.errorMessage).toBeUndefined();
+    expect(retriedJob.polling.attemptCount).toBe(0);
+    expect(retriedJob.statusDetail).toMatch(/re-queued/i);
+  });
+});

--- a/src/lib/executionJobs.ts
+++ b/src/lib/executionJobs.ts
@@ -1,0 +1,200 @@
+import { canBackendTargetAcceptCircuit, type BackendTargetId } from "./backendTargets";
+import type { ExecutableCircuit } from "./circuitExecutor";
+import { type MoleculeKey } from "../data/molecules";
+import type { Algorithm } from "../types";
+import { getExecutionProviderAdapterForTarget } from "./providerAdapters";
+
+export type ExecutionJobStatus = "queued" | "running" | "completed" | "failed";
+
+export type ExecutionJobIntent = "shot-sampling";
+
+export type SamplingExecutionJobRequest =
+  | {
+      targetId: BackendTargetId;
+      circuit: ExecutableCircuit;
+      algorithm: "qaoa";
+      shots: number;
+      nodeCount: number;
+      edges: string[];
+      gammas: number[];
+      betas: number[];
+    }
+  | {
+      targetId: BackendTargetId;
+      circuit: ExecutableCircuit;
+      algorithm: "vqe";
+      shots: number;
+      thetas: number[];
+      molecule: MoleculeKey;
+    };
+
+export type SamplingExecutionJobResult = {
+  estimate: number;
+  totalShotsUsed: number;
+  bitstrings: string[];
+};
+
+export type ExecutionPollingState = {
+  attemptCount: number;
+  retryCount: number;
+  resumable: boolean;
+  lastAttemptedAt?: string;
+  nextSuggestedPollAt?: string;
+  externalJobId?: string;
+};
+
+export type ExecutionJobRecord = {
+  id: string;
+  targetId: BackendTargetId;
+  targetLabel: string;
+  algorithm: Algorithm;
+  intent: ExecutionJobIntent;
+  status: ExecutionJobStatus;
+  submittedAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  shots: number;
+  queueBehavior: "instant" | "provider-queue";
+  statusDetail: string;
+  polling: ExecutionPollingState;
+  result?: SamplingExecutionJobResult;
+  errorMessage?: string;
+};
+
+const EXECUTION_JOBS_STORAGE_KEY = "vqa-sim:execution-jobs";
+const MAX_PERSISTED_EXECUTION_JOBS = 24;
+
+const addMinutesToIsoTimestamp = (timestamp: string, minutes: number): string => {
+  const parsed = new Date(timestamp);
+  parsed.setMinutes(parsed.getMinutes() + minutes);
+  return parsed.toISOString();
+};
+
+const normalizeExecutionJobRecord = (job: Partial<ExecutionJobRecord>): ExecutionJobRecord | null => {
+  if (typeof job.id !== "string") return null;
+  if (typeof job.targetId !== "string") return null;
+  if (typeof job.targetLabel !== "string") return null;
+  if (job.algorithm !== "qaoa" && job.algorithm !== "vqe") return null;
+  if (job.intent !== "shot-sampling") return null;
+  if (job.status !== "queued" && job.status !== "running" && job.status !== "completed" && job.status !== "failed") return null;
+  if (typeof job.submittedAt !== "string" || typeof job.updatedAt !== "string") return null;
+  if (typeof job.shots !== "number") return null;
+  if (job.queueBehavior !== "instant" && job.queueBehavior !== "provider-queue") return null;
+  if (typeof job.statusDetail !== "string") return null;
+
+  const fallbackPolling: ExecutionPollingState =
+    job.queueBehavior === "provider-queue"
+      ? {
+          attemptCount: 0,
+          retryCount: 0,
+          resumable: true,
+          nextSuggestedPollAt: addMinutesToIsoTimestamp(job.submittedAt, 15),
+        }
+      : { attemptCount: 0, retryCount: 0, resumable: false };
+  const polling = job.polling ?? fallbackPolling;
+
+  return {
+    id: job.id,
+    targetId: job.targetId,
+    targetLabel: job.targetLabel,
+    algorithm: job.algorithm,
+    intent: job.intent,
+    status: job.status,
+    submittedAt: job.submittedAt,
+    updatedAt: job.updatedAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    shots: job.shots,
+    queueBehavior: job.queueBehavior,
+    statusDetail: job.statusDetail,
+    polling: {
+      attemptCount: typeof polling.attemptCount === "number" ? polling.attemptCount : fallbackPolling.attemptCount,
+      retryCount: typeof polling.retryCount === "number" ? polling.retryCount : fallbackPolling.retryCount,
+      resumable: typeof polling.resumable === "boolean" ? polling.resumable : fallbackPolling.resumable,
+      lastAttemptedAt: polling.lastAttemptedAt,
+      nextSuggestedPollAt: polling.nextSuggestedPollAt,
+      externalJobId: polling.externalJobId,
+    },
+    result: job.result,
+    errorMessage: job.errorMessage,
+  };
+};
+
+export const loadExecutionJobs = (): ExecutionJobRecord[] => {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.localStorage.getItem(EXECUTION_JOBS_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as Partial<ExecutionJobRecord>[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((job) => normalizeExecutionJobRecord(job))
+      .filter((job): job is ExecutionJobRecord => job !== null);
+  } catch {
+    return [];
+  }
+};
+
+export const saveExecutionJobs = (jobs: ExecutionJobRecord[]): void => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(EXECUTION_JOBS_STORAGE_KEY, JSON.stringify(jobs.slice(0, MAX_PERSISTED_EXECUTION_JOBS)));
+};
+
+export const submitSamplingExecutionJob = (request: SamplingExecutionJobRequest): ExecutionJobRecord => {
+  const acceptance = canBackendTargetAcceptCircuit(request.targetId, request.circuit);
+  if (!acceptance.supported) {
+    throw new Error(acceptance.reason ?? `Execution target "${request.targetId}" cannot accept the current circuit.`);
+  }
+
+  const timestamp = new Date().toISOString();
+  return getExecutionProviderAdapterForTarget(request.targetId).submitSamplingJob(request, timestamp);
+};
+
+export const pollExecutionJobs = (jobs: ExecutionJobRecord[], nowIso: string = new Date().toISOString()): ExecutionJobRecord[] =>
+  jobs.map((job) => {
+    if (job.queueBehavior !== "provider-queue") return job;
+    if (job.status !== "queued" && job.status !== "running") return job;
+    return getExecutionProviderAdapterForTarget(job.targetId).pollJob(job, nowIso);
+  });
+
+export const markExecutionJobFailed = (
+  job: ExecutionJobRecord,
+  errorMessage: string,
+  failedAt: string = new Date().toISOString(),
+): ExecutionJobRecord => ({
+  ...job,
+  status: "failed",
+  updatedAt: failedAt,
+  statusDetail: `Execution failed for ${job.targetLabel}. Retry after correcting the provider or queue issue.`,
+  errorMessage,
+  polling: {
+    ...job.polling,
+    resumable: false,
+    nextSuggestedPollAt: undefined,
+  },
+});
+
+export const retryExecutionJob = (
+  job: ExecutionJobRecord,
+  retriedAt: string = new Date().toISOString(),
+): ExecutionJobRecord => ({
+  ...job,
+  status: "queued",
+  updatedAt: retriedAt,
+  submittedAt: retriedAt,
+  startedAt: undefined,
+  completedAt: undefined,
+  result: undefined,
+  errorMessage: undefined,
+  statusDetail: `${job.targetLabel} was re-queued for execution. Poll again later for progress.`,
+  polling: {
+    attemptCount: 0,
+    retryCount: job.polling.retryCount + 1,
+    resumable: true,
+    nextSuggestedPollAt: addMinutesToIsoTimestamp(retriedAt, 15),
+    externalJobId: undefined,
+  },
+});

--- a/src/lib/providerAdapters.test.ts
+++ b/src/lib/providerAdapters.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildQaoaExecutionCircuit, buildVqeExecutionCircuit } from "./algorithms";
+import { getExecutionProviderAdapter, getExecutionProviderAdapterForTarget } from "./providerAdapters";
+
+describe("providerAdapters", () => {
+  it("resolves adapters by provider and backend target", () => {
+    expect(getExecutionProviderAdapter("local").provider).toBe("local");
+    expect(getExecutionProviderAdapter("ionq").provider).toBe("ionq");
+    expect(getExecutionProviderAdapterForTarget("dense-cpu").provider).toBe("local");
+    expect(getExecutionProviderAdapterForTarget("ionq-qpu").provider).toBe("ionq");
+  });
+
+  it("submits local jobs through the local adapter as immediate completions", () => {
+    const adapter = getExecutionProviderAdapter("local");
+    const job = adapter.submitSamplingJob(
+      {
+        targetId: "dense-cpu",
+        circuit: buildQaoaExecutionCircuit(2, [[0, 1]], [], []),
+        algorithm: "qaoa",
+        shots: 4,
+        nodeCount: 2,
+        edges: ["0-1"],
+        gammas: [],
+        betas: [],
+      },
+      "2026-04-02T12:00:00.000Z",
+    );
+
+    expect(job.status).toBe("completed");
+    expect(job.queueBehavior).toBe("instant");
+    expect(job.result?.bitstrings).toHaveLength(4);
+    expect(job.submittedAt).toBe("2026-04-02T12:00:00.000Z");
+  });
+
+  it("submits remote jobs through the IonQ adapter as queued work", () => {
+    const adapter = getExecutionProviderAdapter("ionq");
+    const job = adapter.submitSamplingJob(
+      {
+        targetId: "ionq-simulator",
+        circuit: buildVqeExecutionCircuit([]),
+        algorithm: "vqe",
+        shots: 32,
+        thetas: [],
+        molecule: "H2_0.74",
+      },
+      "2026-04-02T12:00:00.000Z",
+    );
+
+    expect(job.status).toBe("queued");
+    expect(job.queueBehavior).toBe("provider-queue");
+    expect(job.polling.nextSuggestedPollAt).toBe("2026-04-02T12:15:00.000Z");
+  });
+
+  it("polls queued remote jobs into a running state", () => {
+    const adapter = getExecutionProviderAdapter("ionq");
+    const queuedJob = adapter.submitSamplingJob(
+      {
+        targetId: "ionq-qpu",
+        circuit: buildVqeExecutionCircuit([]),
+        algorithm: "vqe",
+        shots: 16,
+        thetas: [],
+        molecule: "H2_0.74",
+      },
+      "2026-04-02T12:00:00.000Z",
+    );
+
+    const runningJob = adapter.pollJob(queuedJob, "2026-04-02T12:30:00.000Z");
+
+    expect(runningJob.status).toBe("running");
+    expect(runningJob.startedAt).toBe("2026-04-02T12:30:00.000Z");
+    expect(runningJob.polling.attemptCount).toBe(1);
+    expect(runningJob.polling.externalJobId).toMatch(/^remote_/);
+  });
+});

--- a/src/lib/providerAdapters.ts
+++ b/src/lib/providerAdapters.ts
@@ -1,0 +1,156 @@
+import {
+  sampleQaoaMeasurementEstimate,
+  sampleVqeMeasurementEstimate,
+  type SampledMetricEstimate,
+} from "./algorithms";
+import {
+  getBackendTargetDescriptor,
+  type BackendProvider,
+  type BackendTargetId,
+} from "./backendTargets";
+import type {
+  ExecutionJobRecord,
+  ExecutionPollingState,
+  SamplingExecutionJobRequest,
+  SamplingExecutionJobResult,
+} from "./executionJobs";
+
+export interface ExecutionProviderAdapter {
+  readonly provider: BackendProvider;
+  submitSamplingJob(request: SamplingExecutionJobRequest, submittedAt: string): ExecutionJobRecord;
+  pollJob(job: ExecutionJobRecord, nowIso: string): ExecutionJobRecord;
+}
+
+const addMinutesToIsoTimestamp = (timestamp: string, minutes: number): string => {
+  const parsed = new Date(timestamp);
+  parsed.setMinutes(parsed.getMinutes() + minutes);
+  return parsed.toISOString();
+};
+
+const toSamplingJobResult = (estimate: SampledMetricEstimate): SamplingExecutionJobResult => ({
+  estimate: estimate.estimatedValue,
+  totalShotsUsed: estimate.totalShotsUsed,
+  bitstrings: estimate.bitstrings,
+});
+
+const runLocalSamplingJob = (request: SamplingExecutionJobRequest): SamplingExecutionJobResult => {
+  if (request.algorithm === "qaoa") {
+    return toSamplingJobResult(
+      sampleQaoaMeasurementEstimate(
+        request.nodeCount,
+        request.edges,
+        request.gammas,
+        request.betas,
+        request.shots,
+        "dense-cpu",
+      ),
+    );
+  }
+
+  return toSamplingJobResult(sampleVqeMeasurementEstimate(request.thetas, request.molecule, request.shots, "dense-cpu"));
+};
+
+const makeQueuedPollingState = (submittedAt: string): ExecutionPollingState => ({
+  attemptCount: 0,
+  retryCount: 0,
+  resumable: true,
+  nextSuggestedPollAt: addMinutesToIsoTimestamp(submittedAt, 15),
+});
+
+const localProviderAdapter: ExecutionProviderAdapter = {
+  provider: "local",
+  submitSamplingJob(request, submittedAt) {
+    const descriptor = getBackendTargetDescriptor(request.targetId);
+    const result = runLocalSamplingJob(request);
+
+    return {
+      id: `job_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+      targetId: request.targetId,
+      targetLabel: descriptor.label,
+      algorithm: request.algorithm,
+      intent: "shot-sampling",
+      status: "completed",
+      submittedAt,
+      updatedAt: submittedAt,
+      startedAt: submittedAt,
+      completedAt: submittedAt,
+      shots: request.shots,
+      queueBehavior: "instant",
+      statusDetail: `Completed immediately on ${descriptor.label}.`,
+      polling: {
+        attemptCount: 0,
+        retryCount: 0,
+        resumable: false,
+      },
+      result,
+    };
+  },
+  pollJob(job) {
+    return job;
+  },
+};
+
+const ionqProviderAdapter: ExecutionProviderAdapter = {
+  provider: "ionq",
+  submitSamplingJob(request, submittedAt) {
+    const descriptor = getBackendTargetDescriptor(request.targetId);
+
+    return {
+      id: `job_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+      targetId: request.targetId,
+      targetLabel: descriptor.label,
+      algorithm: request.algorithm,
+      intent: "shot-sampling",
+      status: "queued",
+      submittedAt,
+      updatedAt: submittedAt,
+      shots: request.shots,
+      queueBehavior: "provider-queue",
+      statusDetail: `${descriptor.label} is modeled as a queued remote target. Polling and result retrieval are not implemented yet.`,
+      polling: makeQueuedPollingState(submittedAt),
+    };
+  },
+  pollJob(job, nowIso) {
+    if (job.status !== "queued" && job.status !== "running") {
+      return job;
+    }
+
+    const nextAttemptCount = job.polling.attemptCount + 1;
+    const nextPollingState: ExecutionPollingState = {
+      ...job.polling,
+      attemptCount: nextAttemptCount,
+      lastAttemptedAt: nowIso,
+      nextSuggestedPollAt: addMinutesToIsoTimestamp(nowIso, job.status === "queued" ? 30 : 120),
+      externalJobId: job.polling.externalJobId ?? `remote_${job.id}`,
+    };
+
+    if (job.status === "queued") {
+      return {
+        ...job,
+        status: "running",
+        updatedAt: nowIso,
+        startedAt: job.startedAt ?? nowIso,
+        statusDetail: `${job.targetLabel} acknowledged the job. Continue polling later for completion.`,
+        polling: nextPollingState,
+      };
+    }
+
+    return {
+      ...job,
+      updatedAt: nowIso,
+      statusDetail: `${job.targetLabel} is still running remotely. Last checked at ${new Date(nowIso).toLocaleString()}.`,
+      polling: nextPollingState,
+    };
+  },
+};
+
+const PROVIDER_ADAPTERS: Record<BackendProvider, ExecutionProviderAdapter> = {
+  local: localProviderAdapter,
+  ionq: ionqProviderAdapter,
+};
+
+export const getExecutionProviderAdapter = (provider: BackendProvider): ExecutionProviderAdapter =>
+  PROVIDER_ADAPTERS[provider];
+
+export const getExecutionProviderAdapterForTarget = (targetId: BackendTargetId): ExecutionProviderAdapter =>
+  getExecutionProviderAdapter(getBackendTargetDescriptor(targetId).provider);

--- a/src/lib/quantumSimulator.test.ts
+++ b/src/lib/quantumSimulator.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { evaluateQaoaCost } from "./algorithms";
+import {
+  computeQaoaObjectiveGradients,
+  computeVqeObjectiveGradients,
+  evaluateQaoaCost,
+  evaluateVqeEnergy,
+} from "./algorithms";
 import { QuantumSimulator } from "./quantumSimulator";
 
 describe("QuantumSimulator", () => {
@@ -20,4 +25,42 @@ describe("evaluateQaoaCost", () => {
   it("rejects malformed edge strings", () => {
     expect(() => evaluateQaoaCost(3, ["-1-2"], [0.7], [0.35])).toThrow(/expected format/i);
   });
+
+  it("matches the current QAOA cost baseline for representative parameters", () => {
+    expect(evaluateQaoaCost(4, ["0-1", "1-2", "2-3", "3-0"], [0.7, 0.2], [0.35, 0.15])).toBeCloseTo(
+      0.9637691433204479,
+      12,
+    );
+    expect(evaluateQaoaCost(3, ["0-1", "1-2"], [0.4], [0.1])).toBeCloseTo(0.854338772396015, 12);
+  });
+
+  it("matches the current QAOA gradient baseline", () => {
+    const gradients = computeQaoaObjectiveGradients(3, ["0-1", "1-2"], [0.4], [0.1]);
+
+    expect(gradients.gammaGrads).toHaveLength(1);
+    expect(gradients.betaGrads).toHaveLength(1);
+    expect(gradients.gammaGrads[0]).toBeCloseTo(0.31499420863952476, 12);
+    expect(gradients.betaGrads[0]).toBeCloseTo(1.378084805037461, 12);
+  });
 });
+
+describe("evaluateVqeEnergy", () => {
+  it("matches the current VQE energy baseline for representative molecules", () => {
+    expect(evaluateVqeEnergy([0.25, 0.125, 0.08333333333333333, 0.0625], "H2_0.74")).toBeCloseTo(
+      -1.057439901983342,
+      12,
+    );
+    expect(evaluateVqeEnergy([0.2, -0.3, 0.4, -0.1], "HeH")).toBeCloseTo(-2.9849064801934384, 12);
+  });
+
+  it("matches the current VQE gradient baseline", () => {
+    const gradients = computeVqeObjectiveGradients([0.2, -0.3, 0.4, -0.1], "HeH");
+
+    expect(gradients).toHaveLength(4);
+    expect(gradients[0]).toBeCloseTo(-0.16093626503144165, 12);
+    expect(gradients[1]).toBeCloseTo(0.05999962889059174, 12);
+    expect(gradients[2]).toBeCloseTo(-0.1956950580014687, 12);
+    expect(gradients[3]).toBeCloseTo(0.030503401541742914, 12);
+  });
+});
+

--- a/src/lib/quantumSimulator.ts
+++ b/src/lib/quantumSimulator.ts
@@ -1,12 +1,12 @@
-type Complex = { re: number; im: number };
+export type ComplexAmplitude = { re: number; im: number };
 
-const cAdd = (a: Complex, b: Complex): Complex => ({ re: a.re + b.re, im: a.im + b.im });
-const cMul = (a: Complex, b: Complex): Complex => ({
+const cAdd = (a: ComplexAmplitude, b: ComplexAmplitude): ComplexAmplitude => ({ re: a.re + b.re, im: a.im + b.im });
+const cMul = (a: ComplexAmplitude, b: ComplexAmplitude): ComplexAmplitude => ({
   re: a.re * b.re - a.im * b.im,
   im: a.re * b.im + a.im * b.re,
 });
-const cScale = (a: Complex, x: number): Complex => ({ re: a.re * x, im: a.im * x });
-const cProb = (a: Complex): number => a.re * a.re + a.im * a.im;
+const cScale = (a: ComplexAmplitude, x: number): ComplexAmplitude => ({ re: a.re * x, im: a.im * x });
+const cProb = (a: ComplexAmplitude): number => a.re * a.re + a.im * a.im;
 
 const assertValidQubitIndex = (nQubits: number, qubit: number): void => {
   if (!Number.isInteger(qubit) || qubit < 0 || qubit >= nQubits) {
@@ -17,7 +17,7 @@ const assertValidQubitIndex = (nQubits: number, qubit: number): void => {
 export class QuantumSimulator {
   readonly nQubits: number;
   readonly dim: number;
-  state: Complex[];
+  state: ComplexAmplitude[];
 
   constructor(nQubits: number) {
     if (!Number.isInteger(nQubits) || nQubits < 1) {
@@ -36,10 +36,10 @@ export class QuantumSimulator {
 
   private applySingleQubit(
     qubit: number,
-    m00: Complex,
-    m01: Complex,
-    m10: Complex,
-    m11: Complex,
+    m00: ComplexAmplitude,
+    m01: ComplexAmplitude,
+    m10: ComplexAmplitude,
+    m11: ComplexAmplitude,
   ): void {
     assertValidQubitIndex(this.nQubits, qubit);
     const bit = 1 << qubit;
@@ -76,7 +76,7 @@ export class QuantumSimulator {
     const bitA = 1 << qa;
     const bitB = 1 << qb;
     const c = Math.cos(theta / 2);
-    const minusIS: Complex = { re: 0, im: -Math.sin(theta / 2) };
+    const minusIS: ComplexAmplitude = { re: 0, im: -Math.sin(theta / 2) };
 
     for (let i = 0; i < this.dim; i += 1) {
       if ((i & bitA) !== 0 || (i & bitB) !== 0) continue;


### PR DESCRIPTION
## Summary
- group the energy chart and measurement dashboard into a shared analysis workspace
- stabilize the circuit executor API and backend target model
- add a unified execution job queue for local and future remote backends
- introduce provider adapter boundaries and persisted backend/job configuration

## Verification
- bun run test
- bun run build

Closes #3
Refs #2