### PR TITLE
Harden density backend simulator coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 
 .env
 .env.*

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "3.2.4",
         "autoprefixer": "^10.4.20",
         "jsdom": "^26.1.0",
         "postcss": "^8.4.49",
@@ -29,6 +30,8 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -71,6 +74,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -134,6 +139,10 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -149,6 +158,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -234,6 +245,8 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -264,11 +277,17 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
     "autoprefixer": ["autoprefixer@10.4.24", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001766", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -286,9 +305,15 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -314,7 +339,11 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.302", "", {}, "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -336,6 +365,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -344,11 +375,17 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -364,15 +401,29 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
@@ -394,11 +445,19 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -416,9 +475,15 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -484,7 +549,13 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -492,17 +563,29 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -554,7 +637,13 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
@@ -566,6 +655,8 @@
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -576,10 +667,38 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "validate:ionq": "bun scripts/validate-ionq.ts"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "3.2.4",
     "autoprefixer": "^10.4.20",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.49",

--- a/src/lib/circuitExecutor.test.ts
+++ b/src/lib/circuitExecutor.test.ts
@@ -16,12 +16,58 @@ import {
   getCircuitExecutor,
   sampleCircuitBitstrings,
   supportsCapability,
+  type CircuitOperation,
   type ExecutableCircuit,
+  type Observable,
 } from "./circuitExecutor";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
+
+const createSeededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+};
+
+const buildRandomCircuit = (seed: number, qubitCount: 1 | 2, operationCount: number): ExecutableCircuit => {
+  const random = createSeededRandom(seed);
+  const operations: CircuitOperation[] = [];
+
+  for (let index = 0; index < operationCount; index += 1) {
+    const theta = (random() * 2 - 1) * Math.PI;
+
+    if (qubitCount === 1) {
+      operations.push(random() < 0.5 ? { kind: "rx", qubit: 0, theta } : { kind: "ry", qubit: 0, theta });
+      continue;
+    }
+
+    const gateSelector = random();
+    if (gateSelector < 0.4) {
+      operations.push({ kind: "rx", qubit: random() < 0.5 ? 0 : 1, theta });
+    } else if (gateSelector < 0.8) {
+      operations.push({ kind: "ry", qubit: random() < 0.5 ? 0 : 1, theta });
+    } else {
+      operations.push(random() < 0.5 ? { kind: "xx", q1: 0, q2: 1, theta } : { kind: "xx", q1: 1, q2: 0, theta });
+    }
+  }
+
+  return {
+    qubitCount,
+    operations,
+  };
+};
+
+const buildDefaultObservables = (qubitCount: number): Observable[] => {
+  const observables: Observable[] = Array.from({ length: qubitCount }, (_, qubit) => ({ kind: "z", qubit }));
+  if (qubitCount >= 2) {
+    observables.push({ kind: "zz", q1: 0, q2: 1 }, { kind: "xx", q1: 0, q2: 1 });
+  }
+  return observables;
+};
 
 describe("DenseCpuCircuitExecutor", () => {
   it("exposes backend metadata and capabilities", () => {
@@ -235,6 +281,34 @@ describe("DensityCpuCircuitExecutor", () => {
     });
   });
 
+  it("matches dense-cpu observables across deterministic randomized ideal circuits", () => {
+    const cases = [
+      { seed: 11, qubitCount: 1 as const, operationCount: 5 },
+      { seed: 19, qubitCount: 1 as const, operationCount: 7 },
+      { seed: 23, qubitCount: 2 as const, operationCount: 4 },
+      { seed: 29, qubitCount: 2 as const, operationCount: 6 },
+      { seed: 31, qubitCount: 2 as const, operationCount: 8 },
+      { seed: 37, qubitCount: 2 as const, operationCount: 9 },
+      { seed: 41, qubitCount: 2 as const, operationCount: 10 },
+      { seed: 43, qubitCount: 2 as const, operationCount: 12 },
+    ];
+
+    for (const testCase of cases) {
+      const circuit = buildRandomCircuit(testCase.seed, testCase.qubitCount, testCase.operationCount);
+      const observables = buildDefaultObservables(testCase.qubitCount);
+      const denseValues = evaluateCircuitObservables(circuit, observables, "dense-cpu");
+      const densityValues = evaluateCircuitObservables(circuit, observables, "density-cpu");
+
+      expect(densityValues.length).toBe(denseValues.length);
+      densityValues.forEach((value, index) => {
+        expect(
+          value,
+          `seed=${testCase.seed} qubits=${testCase.qubitCount} ops=${testCase.operationCount} observable=${index}`,
+        ).toBeCloseTo(denseValues[index]!, 9);
+      });
+    }
+  });
+
   it("executes a real depolarizing noise path", () => {
     const idealResult = executeCircuit({
       backend: "density-cpu",
@@ -278,6 +352,33 @@ describe("DensityCpuCircuitExecutor", () => {
     const densitySamples = sampleCircuitBitstrings(circuit, 8, "density-cpu");
 
     expect(densitySamples).toEqual(denseSamples);
+  });
+
+  it("matches dense-cpu sampled bitstrings across deterministic randomized ideal circuits", () => {
+    const randomSpy = vi.spyOn(Math, "random");
+    const cases = [
+      { seed: 101, qubitCount: 1 as const, operationCount: 6, shots: 24 },
+      { seed: 103, qubitCount: 1 as const, operationCount: 8, shots: 24 },
+      { seed: 107, qubitCount: 2 as const, operationCount: 5, shots: 32 },
+      { seed: 109, qubitCount: 2 as const, operationCount: 7, shots: 32 },
+      { seed: 113, qubitCount: 2 as const, operationCount: 9, shots: 32 },
+      { seed: 127, qubitCount: 2 as const, operationCount: 11, shots: 32 },
+    ];
+
+    for (const testCase of cases) {
+      const circuit = buildRandomCircuit(testCase.seed, testCase.qubitCount, testCase.operationCount);
+
+      randomSpy.mockImplementation(createSeededRandom(testCase.seed * 17));
+      const denseSamples = sampleCircuitBitstrings(circuit, testCase.shots, "dense-cpu");
+
+      randomSpy.mockImplementation(createSeededRandom(testCase.seed * 17));
+      const densitySamples = sampleCircuitBitstrings(circuit, testCase.shots, "density-cpu");
+
+      expect(
+        densitySamples,
+        `seed=${testCase.seed} qubits=${testCase.qubitCount} ops=${testCase.operationCount}`,
+      ).toEqual(denseSamples);
+    }
   });
 
   it("samples from the noisy density path using depolarized populations", () => {

--- a/src/lib/circuitExecutor.test.ts
+++ b/src/lib/circuitExecutor.test.ts
@@ -259,6 +259,44 @@ describe("DensityCpuCircuitExecutor", () => {
     expect(noisyResult.expectationValues?.values[0]).toBeCloseTo(-0.6, 9);
   });
 
+  it("matches dense-cpu sampling in ideal mode for shared random draws", () => {
+    const circuit: ExecutableCircuit = {
+      qubitCount: 2,
+      operations: [
+        { kind: "ry", qubit: 0, theta: Math.PI / 2 },
+        { kind: "rx", qubit: 1, theta: Math.PI / 3 },
+        { kind: "xx", q1: 0, q2: 1, theta: Math.PI / 4 },
+      ],
+    };
+    const sampleSequence = [0.02, 0.18, 0.33, 0.51, 0.68, 0.82, 0.94, 0.99];
+
+    vi.spyOn(Math, "random").mockImplementation(() => sampleSequence.shift() ?? 0.02);
+    const denseSamples = sampleCircuitBitstrings(circuit, 8, "dense-cpu");
+
+    const densitySequence = [0.02, 0.18, 0.33, 0.51, 0.68, 0.82, 0.94, 0.99];
+    vi.spyOn(Math, "random").mockImplementation(() => densitySequence.shift() ?? 0.02);
+    const densitySamples = sampleCircuitBitstrings(circuit, 8, "density-cpu");
+
+    expect(densitySamples).toEqual(denseSamples);
+  });
+
+  it("samples from the noisy density path using depolarized populations", () => {
+    const samples = [0.1, 0.19, 0.21, 0.79, 0.81];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.1);
+
+    expect(
+      sampleCircuitBitstrings(
+        {
+          qubitCount: 1,
+          operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+        },
+        5,
+        "density-cpu",
+        { kind: "depolarizing", probability: 0.3 },
+      ),
+    ).toEqual(["0", "0", "1", "1", "1"]);
+  });
+
   it("rejects state-vector requests for the density backend", () => {
     expect(() =>
       executeCircuit({

--- a/src/lib/densityMatrixSimulator.test.ts
+++ b/src/lib/densityMatrixSimulator.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it } from "vitest";
-import { DensityMatrixSimulator, maxPopulationDifference } from "./densityMatrixSimulator";
+import { describe, expect, it, vi } from "vitest";
+import { DensityMatrixSimulator, maxPopulationDifference, probabilitiesToBitstrings } from "./densityMatrixSimulator";
 import { QuantumSimulator } from "./quantumSimulator";
+
+type SimulatorStep = {
+  label: string;
+  apply: (simulator: QuantumSimulator | DensityMatrixSimulator) => void;
+};
+
+const buildDensityFromStateVector = (stateVector: QuantumSimulator): DensityMatrixSimulator => {
+  const densityFromStateVector = new DensityMatrixSimulator(stateVector.nQubits);
+  densityFromStateVector.densityMatrix = Array.from({ length: stateVector.dim }, (_, row) =>
+    Array.from({ length: stateVector.dim }, (_, column) => {
+      const a = stateVector.state[row]!;
+      const b = stateVector.state[column]!;
+      return {
+        re: a.re * b.re + a.im * b.im,
+        im: a.im * b.re - a.re * b.im,
+      };
+    }),
+  );
+  return densityFromStateVector;
+};
 
 describe("DensityMatrixSimulator", () => {
   it("matches the state-vector simulator on basis-state populations in ideal mode", () => {
@@ -15,19 +35,58 @@ describe("DensityMatrixSimulator", () => {
     densityMatrix.applyRx(1, Math.PI / 3);
     densityMatrix.applyXX(0, 1, Math.PI / 4);
 
-    const densityFromStateVector = new DensityMatrixSimulator(2);
-    densityFromStateVector.densityMatrix = Array.from({ length: stateVector.dim }, (_, row) =>
-      Array.from({ length: stateVector.dim }, (_, column) => {
-        const a = stateVector.state[row]!;
-        const b = stateVector.state[column]!;
-        return {
-          re: a.re * b.re + a.im * b.im,
-          im: a.im * b.re - a.re * b.im,
-        };
-      }),
-    );
+    const densityFromStateVector = buildDensityFromStateVector(stateVector);
 
     expect(maxPopulationDifference(densityMatrix, densityFromStateVector)).toBeLessThan(1e-9);
+  });
+
+  it("matches state-vector expectations across representative ideal circuits", () => {
+    const cases: Array<{ nQubits: number; steps: SimulatorStep[] }> = [
+      {
+        nQubits: 1,
+        steps: [{ label: "ry(0, pi/2)", apply: (simulator) => simulator.applyRy(0, Math.PI / 2) }],
+      },
+      {
+        nQubits: 2,
+        steps: [
+          { label: "rx(0, pi/5)", apply: (simulator) => simulator.applyRx(0, Math.PI / 5) },
+          { label: "ry(1, -pi/3)", apply: (simulator) => simulator.applyRy(1, -Math.PI / 3) },
+          { label: "xx(0, 1, pi/7)", apply: (simulator) => simulator.applyXX(0, 1, Math.PI / 7) },
+        ],
+      },
+      {
+        nQubits: 2,
+        steps: [
+          { label: "ry(0, pi/2)", apply: (simulator) => simulator.applyRy(0, Math.PI / 2) },
+          { label: "rx(1, pi/3)", apply: (simulator) => simulator.applyRx(1, Math.PI / 3) },
+          { label: "xx(1, 0, -pi/4)", apply: (simulator) => simulator.applyXX(1, 0, -Math.PI / 4) },
+          { label: "rx(0, pi/8)", apply: (simulator) => simulator.applyRx(0, Math.PI / 8) },
+        ],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const stateVector = new QuantumSimulator(testCase.nQubits);
+      const densityMatrix = new DensityMatrixSimulator(testCase.nQubits);
+
+      for (const step of testCase.steps) {
+        step.apply(stateVector);
+        step.apply(densityMatrix);
+      }
+
+      const densityFromStateVector = buildDensityFromStateVector(stateVector);
+      expect(maxPopulationDifference(densityMatrix, densityFromStateVector), testCase.steps.map((step) => step.label).join(" -> "))
+        .toBeLessThan(1e-9);
+
+      for (let qubit = 0; qubit < testCase.nQubits; qubit += 1) {
+        expect(densityMatrix.expZ(qubit)).toBeCloseTo(stateVector.expZ(qubit), 9);
+      }
+
+      if (testCase.nQubits > 1) {
+        expect(densityMatrix.expZZ(0, 1)).toBeCloseTo(stateVector.expZZ(0, 1), 9);
+        expect(densityMatrix.expXX(0, 1)).toBeCloseTo(stateVector.expXX(0, 1), 9);
+      }
+    }
   });
 
   it("applies single-qubit depolarizing noise to reduce z expectation", () => {
@@ -50,5 +109,40 @@ describe("DensityMatrixSimulator", () => {
     expect(beforeNoise).toBeCloseTo(-1, 9);
     expect(afterNoise).toBeGreaterThan(beforeNoise);
     expect(afterNoise).toBeCloseTo(-0.6, 9);
+  });
+
+  it("preserves normalized non-negative populations under multi-qubit depolarizing noise", () => {
+    const simulator = new DensityMatrixSimulator(2);
+    simulator.applyRy(0, Math.PI / 2);
+    simulator.applyRx(1, Math.PI / 3);
+    simulator.applyXX(0, 1, Math.PI / 4);
+    simulator.applySingleQubitDepolarizing(0, 0.2);
+    simulator.applySingleQubitDepolarizing(1, 0.35);
+
+    const probabilities = simulator.measurementProbabilities();
+    const totalProbability = probabilities.reduce((sum, probability) => sum + probability, 0);
+
+    expect(totalProbability).toBeCloseTo(1, 12);
+    probabilities.forEach((probability) => {
+      expect(probability).toBeGreaterThanOrEqual(-1e-12);
+      expect(probability).toBeLessThanOrEqual(1 + 1e-12);
+    });
+    expect(Math.abs(simulator.expZ(0))).toBeLessThanOrEqual(1 + 1e-12);
+    expect(Math.abs(simulator.expZ(1))).toBeLessThanOrEqual(1 + 1e-12);
+    expect(Math.abs(simulator.expZZ(0, 1))).toBeLessThanOrEqual(1 + 1e-12);
+    expect(Math.abs(simulator.expXX(0, 1))).toBeLessThanOrEqual(1 + 1e-12);
+  });
+});
+
+describe("probabilitiesToBitstrings", () => {
+  it("samples bitstrings from a normalized probability vector", () => {
+    const samples = [0.05, 0.35, 0.65, 0.95];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.05);
+
+    expect(probabilitiesToBitstrings([0.25, 0.25, 0.25, 0.25], 2, 4)).toEqual(["00", "01", "10", "11"]);
+  });
+
+  it("rejects non-normalized populations", () => {
+    expect(() => probabilitiesToBitstrings([0.4, 0.4], 1, 2)).toThrow(/do not sum to 1/i);
   });
 });

--- a/src/lib/quantumSimulator.test.ts
+++ b/src/lib/quantumSimulator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { MoleculeKey } from "../data/molecules";
 import {
   computeQaoaObjectiveGradients,
   computeVqeObjectiveGradients,
@@ -6,6 +7,34 @@ import {
   evaluateVqeEnergy,
 } from "./algorithms";
 import { QuantumSimulator } from "./quantumSimulator";
+
+const createSeededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+};
+
+const buildRandomAngles = (seed: number, count: number): number[] => {
+  const random = createSeededRandom(seed);
+  return Array.from({ length: count }, () => (random() * 2 - 1) * Math.PI);
+};
+
+const buildRandomEdgeList = (seed: number, nodeCount: number): string[] => {
+  const random = createSeededRandom(seed);
+  const edges: string[] = [];
+
+  for (let q1 = 0; q1 < nodeCount; q1 += 1) {
+    for (let q2 = q1 + 1; q2 < nodeCount; q2 += 1) {
+      if (random() < 0.6) {
+        edges.push(`${q1}-${q2}`);
+      }
+    }
+  }
+
+  return edges.length > 0 ? edges : ["0-1"];
+};
 
 describe("QuantumSimulator", () => {
   it("rejects out-of-range qubit indices", () => {
@@ -42,6 +71,50 @@ describe("evaluateQaoaCost", () => {
     expect(gradients.gammaGrads[0]).toBeCloseTo(0.31499420863952476, 12);
     expect(gradients.betaGrads[0]).toBeCloseTo(1.378084805037461, 12);
   });
+
+  it("matches density-cpu in ideal mode across deterministic randomized QAOA inputs", () => {
+    const cases = [
+      { seed: 211, nodeCount: 2, depth: 1 },
+      { seed: 223, nodeCount: 3, depth: 1 },
+      { seed: 227, nodeCount: 3, depth: 2 },
+      { seed: 229, nodeCount: 4, depth: 2 },
+      { seed: 233, nodeCount: 4, depth: 3 },
+    ];
+
+    for (const testCase of cases) {
+      const edges = buildRandomEdgeList(testCase.seed, testCase.nodeCount);
+      const gammas = buildRandomAngles(testCase.seed + 1, testCase.depth);
+      const betas = buildRandomAngles(testCase.seed + 2, testCase.depth);
+
+      const denseCost = evaluateQaoaCost(testCase.nodeCount, edges, gammas, betas, "dense-cpu");
+      const densityCost = evaluateQaoaCost(testCase.nodeCount, edges, gammas, betas, "density-cpu");
+      const denseGradients = computeQaoaObjectiveGradients(
+        testCase.nodeCount,
+        edges,
+        gammas,
+        betas,
+        "dense-cpu",
+      );
+      const densityGradients = computeQaoaObjectiveGradients(
+        testCase.nodeCount,
+        edges,
+        gammas,
+        betas,
+        "density-cpu",
+      );
+
+      expect(densityCost, `seed=${testCase.seed} cost`).toBeCloseTo(denseCost, 9);
+      expect(densityGradients.gammaGrads).toHaveLength(denseGradients.gammaGrads.length);
+      expect(densityGradients.betaGrads).toHaveLength(denseGradients.betaGrads.length);
+
+      densityGradients.gammaGrads.forEach((value, index) => {
+        expect(value, `seed=${testCase.seed} gammaGrad[${index}]`).toBeCloseTo(denseGradients.gammaGrads[index]!, 9);
+      });
+      densityGradients.betaGrads.forEach((value, index) => {
+        expect(value, `seed=${testCase.seed} betaGrad[${index}]`).toBeCloseTo(denseGradients.betaGrads[index]!, 9);
+      });
+    }
+  });
 });
 
 describe("evaluateVqeEnergy", () => {
@@ -62,5 +135,27 @@ describe("evaluateVqeEnergy", () => {
     expect(gradients[2]).toBeCloseTo(-0.1956950580014687, 12);
     expect(gradients[3]).toBeCloseTo(0.030503401541742914, 12);
   });
-});
 
+  it("matches density-cpu in ideal mode across deterministic randomized VQE inputs", () => {
+    const cases: Array<{ seed: number; depth: number; molecule: MoleculeKey }> = [
+      { seed: 307, depth: 1, molecule: "H2_0.74" },
+      { seed: 311, depth: 2, molecule: "H2_0.74" },
+      { seed: 313, depth: 2, molecule: "HeH" },
+      { seed: 317, depth: 3, molecule: "HeH" },
+    ];
+
+    for (const testCase of cases) {
+      const thetas = buildRandomAngles(testCase.seed, testCase.depth * 2);
+      const denseEnergy = evaluateVqeEnergy(thetas, testCase.molecule, "dense-cpu");
+      const densityEnergy = evaluateVqeEnergy(thetas, testCase.molecule, "density-cpu");
+      const denseGradients = computeVqeObjectiveGradients(thetas, testCase.molecule, "dense-cpu");
+      const densityGradients = computeVqeObjectiveGradients(thetas, testCase.molecule, "density-cpu");
+
+      expect(densityEnergy, `seed=${testCase.seed} energy`).toBeCloseTo(denseEnergy, 9);
+      expect(densityGradients).toHaveLength(denseGradients.length);
+      densityGradients.forEach((value, index) => {
+        expect(value, `seed=${testCase.seed} thetaGrad[${index}]`).toBeCloseTo(denseGradients[index]!, 9);
+      });
+    }
+  });
+});

--- a/src/lib/quantumSimulator.test.ts
+++ b/src/lib/quantumSimulator.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { MoleculeKey } from "../data/molecules";
 import {
+  sampleQaoaMeasurementEstimate,
+  sampleVqeMeasurementEstimate,
   computeQaoaObjectiveGradients,
   computeVqeObjectiveGradients,
   evaluateQaoaCost,
@@ -115,6 +117,42 @@ describe("evaluateQaoaCost", () => {
       });
     }
   });
+
+  it("moves QAOA cost toward the unstructured baseline under stronger depolarizing noise", () => {
+    const noiseLevels = [0, 0.05, 0.15, 0.3] as const;
+    const values = noiseLevels.map((probability) =>
+      evaluateQaoaCost(
+        2,
+        ["0-1"],
+        [0.7],
+        [0.35],
+        "density-cpu",
+        probability === 0 ? { kind: "ideal" } : { kind: "depolarizing", probability },
+      ),
+    );
+
+    expect(values[0]).toBeCloseTo(0.18257792702891362, 12);
+    expect(values[1]!).toBeGreaterThan(values[0]!);
+    expect(values[2]!).toBeGreaterThan(values[1]!);
+    expect(values[3]!).toBeGreaterThan(values[2]!);
+    expect(Math.abs(values[3]! - 0.5)).toBeLessThan(Math.abs(values[0]! - 0.5));
+  });
+
+  it("makes noisy QAOA shot estimates converge toward the exact noisy density value", () => {
+    const random = createSeededRandom(12345);
+    const noiseModel = { kind: "depolarizing", probability: 0.15 } as const;
+    const exact = evaluateQaoaCost(2, ["0-1"], [0.7], [0.35], "density-cpu", noiseModel);
+
+    const originalRandom = Math.random;
+    try {
+      Math.random = random;
+      const sampled = sampleQaoaMeasurementEstimate(2, ["0-1"], [0.7], [0.35], 4096, "density-cpu", noiseModel);
+      expect(sampled.estimatedValue).toBeCloseTo(exact, 1);
+      expect(sampled.totalShotsUsed).toBe(4096);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
 });
 
 describe("evaluateVqeEnergy", () => {
@@ -156,6 +194,39 @@ describe("evaluateVqeEnergy", () => {
       densityGradients.forEach((value, index) => {
         expect(value, `seed=${testCase.seed} thetaGrad[${index}]`).toBeCloseTo(denseGradients[index]!, 9);
       });
+    }
+  });
+
+  it("makes representative VQE energies less favorable under stronger depolarizing noise", () => {
+    const noiseLevels = [0, 0.05, 0.15, 0.3] as const;
+    const values = noiseLevels.map((probability) =>
+      evaluateVqeEnergy(
+        [0.2, -0.3, 0.4, -0.1],
+        "HeH",
+        "density-cpu",
+        probability === 0 ? { kind: "ideal" } : { kind: "depolarizing", probability },
+      ),
+    );
+
+    expect(values[1]!).toBeGreaterThan(values[0]!);
+    expect(values[2]!).toBeGreaterThan(values[1]!);
+    expect(values[3]!).toBeGreaterThan(values[2]!);
+  });
+
+  it("makes noisy VQE shot estimates converge toward the exact noisy density value", () => {
+    const random = createSeededRandom(67890);
+    const noiseModel = { kind: "depolarizing", probability: 0.15 } as const;
+    const thetas = [0.2, -0.3, 0.4, -0.1];
+    const exact = evaluateVqeEnergy(thetas, "HeH", "density-cpu", noiseModel);
+
+    const originalRandom = Math.random;
+    try {
+      Math.random = random;
+      const sampled = sampleVqeMeasurementEstimate(thetas, "HeH", 4096, "density-cpu", noiseModel);
+      expect(sampled.estimatedValue).toBeCloseTo(exact, 1);
+      expect(sampled.totalShotsUsed).toBe(8192);
+    } finally {
+      Math.random = originalRandom;
     }
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,16 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
+    coverage: {
+      provider: "v8",
+      reportsDirectory: "./coverage",
+      reporter: ["text", "html", "json-summary"],
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/test/**",
+      ],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add Vitest coverage reporting and commit the baseline coverage workflow
- strengthen density-vs-dense simulator correctness checks with deterministic randomized equivalence tests
- add noisy algorithm validation for QAOA and VQE, including sampled-vs-exact convergence checks

Progress on #2