### PR TITLE
Add hardware noise presets for the density backend

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -233,8 +233,10 @@ describe("App", () => {
       JSON.stringify({
         executionTarget: "ionq-simulator",
         ionqCredentialMode: "browser-session",
-        noiseModelKind: "ideal",
+        noiseProfileId: "ideal",
         depolarizingProbability: 0.05,
+        amplitudeDampingProbability: 0.02,
+        readoutErrorProbability: 0.01,
       }),
     );
     expect(window.localStorage.getItem("vqa-sim:provider-session-credentials")).toBeNull();
@@ -248,7 +250,7 @@ describe("App", () => {
     expect(screen.getByLabelText(/ionq api key/i)).toHaveValue("test-ionq-key");
   });
 
-  it("shows density-matrix noise controls and uses the selected depolarizing model for local sampling", async () => {
+  it("shows density-matrix noise controls and uses the selected custom noise model for local sampling", async () => {
     const user = userEvent.setup();
     vi.mocked(sampleQaoaMeasurementEstimate).mockReturnValue({
       bitstrings: ["0011", "0000", "0011", "1100"],
@@ -258,17 +260,18 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(screen.queryByLabelText(/^noise$/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/noise profile/i)).not.toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText(/execution target/i), "density-cpu");
 
-    expect(screen.getByLabelText(/^noise$/i)).toHaveValue("ideal");
+    expect(screen.getByLabelText(/noise profile/i)).toHaveValue("ideal");
     expect(screen.queryByLabelText(/depolarizing probability/i)).not.toBeInTheDocument();
 
-    await user.selectOptions(screen.getByLabelText(/^noise$/i), "depolarizing");
+    await user.selectOptions(screen.getByLabelText(/noise profile/i), "custom");
 
-    const probabilitySlider = screen.getByLabelText(/depolarizing probability/i);
-    fireEvent.change(probabilitySlider, { target: { value: "0.125" } });
+    fireEvent.change(screen.getByLabelText(/depolarizing probability/i), { target: { value: "0.125" } });
+    fireEvent.change(screen.getByLabelText(/amplitude damping/i), { target: { value: "0.04" } });
+    fireEvent.change(screen.getByLabelText(/readout error/i), { target: { value: "0.03" } });
     fireEvent.change(screen.getByLabelText(/measurement shots per batch/i), { target: { value: "4" } });
     await user.click(screen.getByRole("button", { name: /refresh sampled estimate/i }));
     await waitFor(() => expect(sampleQaoaMeasurementEstimate).toHaveBeenCalled());
@@ -280,14 +283,21 @@ describe("App", () => {
       [0.35, 0.175],
       4,
       "density-cpu",
-      { kind: "depolarizing", probability: 0.125 },
+      {
+        kind: "composite",
+        depolarizingProbability: 0.125,
+        amplitudeDampingProbability: 0.04,
+        readoutErrorProbability: 0.03,
+      },
     );
     expect(window.localStorage.getItem("vqa-sim:backend-preferences")).toBe(
       JSON.stringify({
         executionTarget: "density-cpu",
         ionqCredentialMode: "browser-session",
-        noiseModelKind: "depolarizing",
+        noiseProfileId: "custom",
         depolarizingProbability: 0.125,
+        amplitudeDampingProbability: 0.04,
+        readoutErrorProbability: 0.03,
       }),
     );
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import {
   parseAndValidateEdge,
   resizeArray,
 } from "./lib/utils";
+import { resolveNoiseSettingsForProfile } from "./lib/noiseProfiles";
 import type { Algorithm, CircuitMode } from "./types";
 
 type LiveState = {
@@ -188,17 +189,35 @@ export default function App(): JSX.Element {
       };
     }
 
+    const noiseSettings = resolveNoiseSettingsForProfile(backendPreferences.noiseProfileId, {
+      depolarizingProbability: backendPreferences.depolarizingProbability,
+      amplitudeDampingProbability: backendPreferences.amplitudeDampingProbability,
+      readoutErrorProbability: backendPreferences.readoutErrorProbability,
+    });
+
+    const hasNoise =
+      noiseSettings.depolarizingProbability > 0 ||
+      noiseSettings.amplitudeDampingProbability > 0 ||
+      noiseSettings.readoutErrorProbability > 0;
+
     return {
       backend: "density-cpu",
-      noiseModel:
-        backendPreferences.noiseModelKind === "depolarizing"
-          ? {
-              kind: "depolarizing",
-              probability: backendPreferences.depolarizingProbability,
-            }
-          : { kind: "ideal" },
+      noiseModel: hasNoise
+        ? {
+            kind: "composite",
+            depolarizingProbability: noiseSettings.depolarizingProbability,
+            amplitudeDampingProbability: noiseSettings.amplitudeDampingProbability,
+            readoutErrorProbability: noiseSettings.readoutErrorProbability,
+          }
+        : { kind: "ideal" },
     };
-  }, [backendPreferences.depolarizingProbability, backendPreferences.executionTarget, backendPreferences.noiseModelKind]);
+  }, [
+    backendPreferences.amplitudeDampingProbability,
+    backendPreferences.depolarizingProbability,
+    backendPreferences.executionTarget,
+    backendPreferences.noiseProfileId,
+    backendPreferences.readoutErrorProbability,
+  ]);
 
   const currentMetric = useMemo(() => {
     if (algorithm === "qaoa") {
@@ -277,9 +296,11 @@ export default function App(): JSX.Element {
     setSamplingNotice(null);
   }, [
     algorithm,
+    backendPreferences.amplitudeDampingProbability,
     backendPreferences.depolarizingProbability,
     backendPreferences.executionTarget,
-    backendPreferences.noiseModelKind,
+    backendPreferences.noiseProfileId,
+    backendPreferences.readoutErrorProbability,
     betas,
     effectiveEdges,
     gammas,
@@ -630,8 +651,10 @@ export default function App(): JSX.Element {
             <ExecutionBackendPanel
               executionTarget={backendPreferences.executionTarget}
               ionqCredentialMode={backendPreferences.ionqCredentialMode}
-              noiseModelKind={backendPreferences.noiseModelKind}
+              noiseProfileId={backendPreferences.noiseProfileId}
               depolarizingProbability={backendPreferences.depolarizingProbability}
+              amplitudeDampingProbability={backendPreferences.amplitudeDampingProbability}
+              readoutErrorProbability={backendPreferences.readoutErrorProbability}
               ionqApiKey={providerSessionCredentials.ionqApiKey}
               ionqAuthConfigured={selectedExecutionTargetAuthStatus.configured}
               onExecutionTargetChange={(executionTarget) =>
@@ -646,16 +669,28 @@ export default function App(): JSX.Element {
                   ionqCredentialMode,
                 }))
               }
-              onNoiseModelKindChange={(noiseModelKind) =>
+              onNoiseProfileChange={(noiseProfileId) =>
                 setBackendPreferences((prev) => ({
                   ...prev,
-                  noiseModelKind,
+                  noiseProfileId,
                 }))
               }
               onDepolarizingProbabilityChange={(depolarizingProbability) =>
                 setBackendPreferences((prev) => ({
                   ...prev,
                   depolarizingProbability,
+                }))
+              }
+              onAmplitudeDampingProbabilityChange={(amplitudeDampingProbability) =>
+                setBackendPreferences((prev) => ({
+                  ...prev,
+                  amplitudeDampingProbability,
+                }))
+              }
+              onReadoutErrorProbabilityChange={(readoutErrorProbability) =>
+                setBackendPreferences((prev) => ({
+                  ...prev,
+                  readoutErrorProbability,
                 }))
               }
               onIonqApiKeyChange={(ionqApiKey) =>

--- a/src/components/ExecutionBackendPanel.tsx
+++ b/src/components/ExecutionBackendPanel.tsx
@@ -3,19 +3,28 @@ import {
   listBackendTargets,
   type BackendTargetId,
 } from "../lib/backendTargets";
-import type { IonQCredentialMode, NoiseModelKind } from "../lib/backendPreferences";
+import type { IonQCredentialMode } from "../lib/backendPreferences";
+import {
+  getNoiseProfileDescriptor,
+  listNoiseProfiles,
+  type NoiseProfileId,
+} from "../lib/noiseProfiles";
 
 type ExecutionBackendPanelProps = {
   executionTarget: BackendTargetId;
   ionqCredentialMode: IonQCredentialMode;
-  noiseModelKind: NoiseModelKind;
+  noiseProfileId: NoiseProfileId;
   depolarizingProbability: number;
+  amplitudeDampingProbability: number;
+  readoutErrorProbability: number;
   ionqApiKey: string;
   ionqAuthConfigured: boolean;
   onExecutionTargetChange: (target: BackendTargetId) => void;
   onIonqCredentialModeChange: (mode: IonQCredentialMode) => void;
-  onNoiseModelKindChange: (kind: NoiseModelKind) => void;
+  onNoiseProfileChange: (profileId: NoiseProfileId) => void;
   onDepolarizingProbabilityChange: (probability: number) => void;
+  onAmplitudeDampingProbabilityChange: (probability: number) => void;
+  onReadoutErrorProbabilityChange: (probability: number) => void;
   onIonqApiKeyChange: (apiKey: string) => void;
   onClearIonqApiKey: () => void;
 };
@@ -23,14 +32,18 @@ type ExecutionBackendPanelProps = {
 export function ExecutionBackendPanel({
   executionTarget,
   ionqCredentialMode,
-  noiseModelKind,
+  noiseProfileId,
   depolarizingProbability,
+  amplitudeDampingProbability,
+  readoutErrorProbability,
   ionqApiKey,
   ionqAuthConfigured,
   onExecutionTargetChange,
   onIonqCredentialModeChange,
-  onNoiseModelKindChange,
+  onNoiseProfileChange,
   onDepolarizingProbabilityChange,
+  onAmplitudeDampingProbabilityChange,
+  onReadoutErrorProbabilityChange,
   onIonqApiKeyChange,
   onClearIonqApiKey,
 }: ExecutionBackendPanelProps): JSX.Element {
@@ -38,6 +51,9 @@ export function ExecutionBackendPanel({
   const isRemoteTarget = descriptor.executionMode === "remote-job";
   const supportsNoiseControls = executionTarget === "density-cpu";
   const targetOptions = listBackendTargets();
+  const noiseProfileOptions = listNoiseProfiles();
+  const selectedNoiseProfile = getNoiseProfileDescriptor(noiseProfileId);
+  const isCustomNoiseProfile = noiseProfileId === "custom";
   const ionqStatusCopy =
     ionqCredentialMode === "browser-session"
       ? ionqAuthConfigured
@@ -71,36 +87,111 @@ export function ExecutionBackendPanel({
         {supportsNoiseControls ? (
           <div className="space-y-3 rounded-md border border-neutral-800 bg-neutral-900 p-3">
             <div>
-              <label className="mb-1 block text-xs font-medium text-neutral-300" htmlFor="noise-model-kind">
-                Noise
+              <label className="mb-1 block text-xs font-medium text-neutral-300" htmlFor="noise-profile">
+                Noise profile
               </label>
               <select
-                id="noise-model-kind"
-                value={noiseModelKind}
-                onChange={(event) => onNoiseModelKindChange(event.target.value as NoiseModelKind)}
+                id="noise-profile"
+                value={noiseProfileId}
+                onChange={(event) => onNoiseProfileChange(event.target.value as NoiseProfileId)}
                 className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm outline-none ring-cyan-400 focus:ring-2"
               >
-                <option value="ideal">Ideal</option>
-                <option value="depolarizing">Depolarizing</option>
+                {noiseProfileOptions.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.label}
+                  </option>
+                ))}
               </select>
             </div>
 
-            {noiseModelKind === "depolarizing" ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3 text-xs text-neutral-400">
-                  <label htmlFor="depolarizing-probability">Depolarizing probability</label>
-                  <span className="font-mono text-neutral-200">{depolarizingProbability.toFixed(3)}</span>
+            {noiseProfileId !== "ideal" ? (
+              <div className="space-y-3">
+                <div className="grid grid-cols-3 gap-2 text-[11px] uppercase tracking-[0.18em] text-neutral-500">
+                  <div className="rounded-md border border-neutral-800 bg-neutral-950/80 px-2 py-2">
+                    <div>Depol</div>
+                    <div className="mt-1 font-mono text-neutral-200">
+                      {(isCustomNoiseProfile
+                        ? depolarizingProbability
+                        : selectedNoiseProfile.settings.depolarizingProbability
+                      ).toFixed(3)}
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-neutral-800 bg-neutral-950/80 px-2 py-2">
+                    <div>T1</div>
+                    <div className="mt-1 font-mono text-neutral-200">
+                      {(isCustomNoiseProfile
+                        ? amplitudeDampingProbability
+                        : selectedNoiseProfile.settings.amplitudeDampingProbability
+                      ).toFixed(3)}
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-neutral-800 bg-neutral-950/80 px-2 py-2">
+                    <div>Readout</div>
+                    <div className="mt-1 font-mono text-neutral-200">
+                      {(isCustomNoiseProfile
+                        ? readoutErrorProbability
+                        : selectedNoiseProfile.settings.readoutErrorProbability
+                      ).toFixed(3)}
+                    </div>
+                  </div>
                 </div>
-                <input
-                  id="depolarizing-probability"
-                  type="range"
-                  min={0}
-                  max={0.3}
-                  step={0.005}
-                  value={depolarizingProbability}
-                  onChange={(event) => onDepolarizingProbabilityChange(Number.parseFloat(event.target.value))}
-                  className="w-full accent-cyan-400"
-                />
+
+                {isCustomNoiseProfile ? (
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-3 text-xs text-neutral-400">
+                        <label htmlFor="depolarizing-probability">Depolarizing probability</label>
+                        <span className="font-mono text-neutral-200">{depolarizingProbability.toFixed(3)}</span>
+                      </div>
+                      <input
+                        id="depolarizing-probability"
+                        type="range"
+                        min={0}
+                        max={0.2}
+                        step={0.0025}
+                        value={depolarizingProbability}
+                        onChange={(event) => onDepolarizingProbabilityChange(Number.parseFloat(event.target.value))}
+                        className="w-full accent-cyan-400"
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-3 text-xs text-neutral-400">
+                        <label htmlFor="amplitude-damping-probability">Amplitude damping</label>
+                        <span className="font-mono text-neutral-200">{amplitudeDampingProbability.toFixed(3)}</span>
+                      </div>
+                      <input
+                        id="amplitude-damping-probability"
+                        type="range"
+                        min={0}
+                        max={0.2}
+                        step={0.0025}
+                        value={amplitudeDampingProbability}
+                        onChange={(event) =>
+                          onAmplitudeDampingProbabilityChange(Number.parseFloat(event.target.value))
+                        }
+                        className="w-full accent-cyan-400"
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-3 text-xs text-neutral-400">
+                        <label htmlFor="readout-error-probability">Readout error</label>
+                        <span className="font-mono text-neutral-200">{readoutErrorProbability.toFixed(3)}</span>
+                      </div>
+                      <input
+                        id="readout-error-probability"
+                        type="range"
+                        min={0}
+                        max={0.2}
+                        step={0.0025}
+                        value={readoutErrorProbability}
+                        onChange={(event) => onReadoutErrorProbabilityChange(Number.parseFloat(event.target.value))}
+                        className="w-full accent-cyan-400"
+                      />
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/lib/backendPreferences.test.ts
+++ b/src/lib/backendPreferences.test.ts
@@ -27,8 +27,31 @@ describe("backendPreferences", () => {
     expect(loadBackendPreferences()).toEqual({
       executionTarget: "ionq-simulator",
       ionqCredentialMode: "browser-session",
-      noiseModelKind: "ideal",
+      noiseProfileId: "ideal",
       depolarizingProbability: 0.05,
+      amplitudeDampingProbability: 0.02,
+      readoutErrorProbability: 0.01,
+    });
+  });
+
+  it("migrates legacy depolarizing preferences into the custom noise profile", () => {
+    window.localStorage.setItem(
+      "vqa-sim:backend-preferences",
+      JSON.stringify({
+        executionTarget: "density-cpu",
+        ionqCredentialMode: "browser-session",
+        noiseModelKind: "depolarizing",
+        depolarizingProbability: 0.12,
+      }),
+    );
+
+    expect(loadBackendPreferences()).toEqual({
+      executionTarget: "density-cpu",
+      ionqCredentialMode: "browser-session",
+      noiseProfileId: "custom",
+      depolarizingProbability: 0.12,
+      amplitudeDampingProbability: 0.02,
+      readoutErrorProbability: 0.01,
     });
   });
 
@@ -36,8 +59,10 @@ describe("backendPreferences", () => {
     const preferences: BackendPreferences = {
       executionTarget: "ionq-qpu",
       ionqCredentialMode: "server-managed",
-      noiseModelKind: "depolarizing",
+      noiseProfileId: "custom",
       depolarizingProbability: 0.12,
+      amplitudeDampingProbability: 0.04,
+      readoutErrorProbability: 0.03,
     };
 
     saveBackendPreferences(preferences);
@@ -46,8 +71,10 @@ describe("backendPreferences", () => {
       JSON.stringify({
         executionTarget: "ionq-qpu",
         ionqCredentialMode: "server-managed",
-        noiseModelKind: "depolarizing",
+        noiseProfileId: "custom",
         depolarizingProbability: 0.12,
+        amplitudeDampingProbability: 0.04,
+        readoutErrorProbability: 0.03,
       }),
     );
   });

--- a/src/lib/backendPreferences.ts
+++ b/src/lib/backendPreferences.ts
@@ -1,13 +1,20 @@
 import { getBackendTargetDescriptor, type BackendTargetId } from "./backendTargets";
+import {
+  DEFAULT_CUSTOM_NOISE_SETTINGS,
+  isValidNoiseProfileId,
+  normalizeNoiseSettings,
+  type NoiseProfileId,
+} from "./noiseProfiles";
 
 export type IonQCredentialMode = "browser-session" | "server-managed";
-export type NoiseModelKind = "ideal" | "depolarizing";
 
 export type BackendPreferences = {
   executionTarget: BackendTargetId;
   ionqCredentialMode: IonQCredentialMode;
-  noiseModelKind: NoiseModelKind;
+  noiseProfileId: NoiseProfileId;
   depolarizingProbability: number;
+  amplitudeDampingProbability: number;
+  readoutErrorProbability: number;
 };
 
 const BACKEND_PREFERENCES_STORAGE_KEY = "vqa-sim:backend-preferences";
@@ -15,8 +22,10 @@ const BACKEND_PREFERENCES_STORAGE_KEY = "vqa-sim:backend-preferences";
 export const DEFAULT_BACKEND_PREFERENCES: BackendPreferences = {
   executionTarget: "dense-cpu",
   ionqCredentialMode: "browser-session",
-  noiseModelKind: "ideal",
-  depolarizingProbability: 0.05,
+  noiseProfileId: "ideal",
+  depolarizingProbability: DEFAULT_CUSTOM_NOISE_SETTINGS.depolarizingProbability,
+  amplitudeDampingProbability: DEFAULT_CUSTOM_NOISE_SETTINGS.amplitudeDampingProbability,
+  readoutErrorProbability: DEFAULT_CUSTOM_NOISE_SETTINGS.readoutErrorProbability,
 };
 
 const isValidBackendTargetId = (value: unknown): value is BackendTargetId => {
@@ -33,17 +42,6 @@ const isValidBackendTargetId = (value: unknown): value is BackendTargetId => {
 const isValidIonQCredentialMode = (value: unknown): value is IonQCredentialMode =>
   value === "browser-session" || value === "server-managed";
 
-const isValidNoiseModelKind = (value: unknown): value is NoiseModelKind =>
-  value === "ideal" || value === "depolarizing";
-
-const normalizeDepolarizingProbability = (value: unknown): number => {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return DEFAULT_BACKEND_PREFERENCES.depolarizingProbability;
-  }
-
-  return Math.min(1, Math.max(0, value));
-};
-
 export const loadBackendPreferences = (): BackendPreferences => {
   if (typeof window === "undefined") return DEFAULT_BACKEND_PREFERENCES;
 
@@ -52,6 +50,21 @@ export const loadBackendPreferences = (): BackendPreferences => {
     if (!raw) return DEFAULT_BACKEND_PREFERENCES;
 
     const parsed = JSON.parse(raw) as Partial<BackendPreferences>;
+    const legacyNoiseModelKind = (parsed as { noiseModelKind?: unknown }).noiseModelKind;
+    const noiseProfileId = isValidNoiseProfileId(parsed.noiseProfileId)
+      ? parsed.noiseProfileId
+      : legacyNoiseModelKind === "depolarizing"
+        ? "custom"
+        : DEFAULT_BACKEND_PREFERENCES.noiseProfileId;
+    const customNoiseSettings = normalizeNoiseSettings(
+      {
+        depolarizingProbability: parsed.depolarizingProbability,
+        amplitudeDampingProbability: parsed.amplitudeDampingProbability,
+        readoutErrorProbability: parsed.readoutErrorProbability,
+      },
+      DEFAULT_CUSTOM_NOISE_SETTINGS,
+    );
+
     return {
       executionTarget: isValidBackendTargetId(parsed.executionTarget)
         ? parsed.executionTarget
@@ -59,10 +72,10 @@ export const loadBackendPreferences = (): BackendPreferences => {
       ionqCredentialMode: isValidIonQCredentialMode(parsed.ionqCredentialMode)
         ? parsed.ionqCredentialMode
         : DEFAULT_BACKEND_PREFERENCES.ionqCredentialMode,
-      noiseModelKind: isValidNoiseModelKind(parsed.noiseModelKind)
-        ? parsed.noiseModelKind
-        : DEFAULT_BACKEND_PREFERENCES.noiseModelKind,
-      depolarizingProbability: normalizeDepolarizingProbability(parsed.depolarizingProbability),
+      noiseProfileId,
+      depolarizingProbability: customNoiseSettings.depolarizingProbability,
+      amplitudeDampingProbability: customNoiseSettings.amplitudeDampingProbability,
+      readoutErrorProbability: customNoiseSettings.readoutErrorProbability,
     };
   } catch {
     return DEFAULT_BACKEND_PREFERENCES;

--- a/src/lib/circuitExecutor.test.ts
+++ b/src/lib/circuitExecutor.test.ts
@@ -211,6 +211,23 @@ describe("DenseCpuCircuitExecutor", () => {
     ).toThrow(/invalid depolarizing probability/i);
   });
 
+  it("rejects unsupported composite noise requests", () => {
+    expect(() =>
+      denseCpuCircuitExecutor.execute({
+        circuit: {
+          qubitCount: 1,
+          operations: [],
+        },
+        noiseModel: {
+          kind: "composite",
+          depolarizingProbability: 0.02,
+          amplitudeDampingProbability: 0.01,
+          readoutErrorProbability: 0.03,
+        },
+      }),
+    ).toThrow(/unsupported noise model/i);
+  });
+
   it("rejects out-of-range circuit operations before execution", () => {
     expect(() =>
       executeCircuit({
@@ -333,6 +350,25 @@ describe("DensityCpuCircuitExecutor", () => {
     expect(noisyResult.expectationValues?.values[0]).toBeCloseTo(-0.6, 9);
   });
 
+  it("executes amplitude damping on the density backend", () => {
+    const dampedResult = executeCircuit({
+      backend: "density-cpu",
+      circuit: {
+        qubitCount: 1,
+        operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+      },
+      observables: [{ kind: "z", qubit: 0 }],
+      noiseModel: {
+        kind: "composite",
+        depolarizingProbability: 0,
+        amplitudeDampingProbability: 0.3,
+        readoutErrorProbability: 0,
+      },
+    });
+
+    expect(dampedResult.expectationValues?.values[0]).toBeCloseTo(-0.4, 9);
+  });
+
   it("matches dense-cpu sampling in ideal mode for shared random draws", () => {
     const circuit: ExecutableCircuit = {
       qubitCount: 2,
@@ -396,6 +432,46 @@ describe("DensityCpuCircuitExecutor", () => {
         { kind: "depolarizing", probability: 0.3 },
       ),
     ).toEqual(["0", "0", "1", "1", "1"]);
+  });
+
+  it("applies readout error after noisy density sampling", () => {
+    const samples = [0.9, 0.1, 0.3, 0.24, 0.26, 0.8];
+    vi.spyOn(Math, "random").mockImplementation(() => samples.shift() ?? 0.9);
+
+    expect(
+      sampleCircuitBitstrings(
+        {
+          qubitCount: 1,
+          operations: [{ kind: "rx", qubit: 0, theta: Math.PI }],
+        },
+        3,
+        "density-cpu",
+        {
+          kind: "composite",
+          depolarizingProbability: 0,
+          amplitudeDampingProbability: 0,
+          readoutErrorProbability: 0.25,
+        },
+      ),
+    ).toEqual(["0", "1", "1"]);
+  });
+
+  it("rejects invalid composite noise probabilities", () => {
+    expect(() =>
+      executeCircuit({
+        backend: "density-cpu",
+        circuit: {
+          qubitCount: 1,
+          operations: [],
+        },
+        noiseModel: {
+          kind: "composite",
+          depolarizingProbability: 0.1,
+          amplitudeDampingProbability: -0.2,
+          readoutErrorProbability: 0,
+        },
+      }),
+    ).toThrow(/invalid amplitude damping probability/i);
   });
 
   it("rejects state-vector requests for the density backend", () => {

--- a/src/lib/circuitExecutor.ts
+++ b/src/lib/circuitExecutor.ts
@@ -34,6 +34,12 @@ export type NoiseModel =
   | {
       kind: "depolarizing";
       probability: number;
+    }
+  | {
+      kind: "composite";
+      depolarizingProbability: number;
+      amplitudeDampingProbability: number;
+      readoutErrorProbability: number;
     };
 
 export type ExecutionRequest = {
@@ -170,11 +176,63 @@ const assertValidStateVectorRequest = (stateVector?: StateVectorRequest): void =
 const assertValidNoiseModel = (noiseModel?: NoiseModel): void => {
   if (!noiseModel || noiseModel.kind === "ideal") return;
 
-  if (!Number.isFinite(noiseModel.probability) || noiseModel.probability < 0 || noiseModel.probability > 1) {
-    throw new Error(
-      `Invalid depolarizing probability ${noiseModel.probability}; expected a finite value between 0 and 1.`,
-    );
+  const probabilityEntries =
+    noiseModel.kind === "depolarizing"
+      ? [["depolarizing", noiseModel.probability] as const]
+      : ([
+          ["depolarizing", noiseModel.depolarizingProbability],
+          ["amplitude damping", noiseModel.amplitudeDampingProbability],
+          ["readout error", noiseModel.readoutErrorProbability],
+        ] as const);
+
+  for (const [label, value] of probabilityEntries) {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(`Invalid ${label} probability ${value}; expected a finite value between 0 and 1.`);
+    }
   }
+};
+
+type ResolvedNoiseSettings = {
+  depolarizingProbability: number;
+  amplitudeDampingProbability: number;
+  readoutErrorProbability: number;
+};
+
+const resolveNoiseSettings = (noiseModel?: NoiseModel): ResolvedNoiseSettings => {
+  if (!noiseModel || noiseModel.kind === "ideal") {
+    return {
+      depolarizingProbability: 0,
+      amplitudeDampingProbability: 0,
+      readoutErrorProbability: 0,
+    };
+  }
+
+  if (noiseModel.kind === "depolarizing") {
+    return {
+      depolarizingProbability: noiseModel.probability,
+      amplitudeDampingProbability: 0,
+      readoutErrorProbability: 0,
+    };
+  }
+
+  return {
+    depolarizingProbability: noiseModel.depolarizingProbability,
+    amplitudeDampingProbability: noiseModel.amplitudeDampingProbability,
+    readoutErrorProbability: noiseModel.readoutErrorProbability,
+  };
+};
+
+const applyReadoutError = (bitstrings: string[], probability: number): string[] => {
+  if (probability <= 0) return bitstrings;
+
+  return bitstrings.map((bitstring) =>
+    [...bitstring]
+      .map((bit) => {
+        if (Math.random() >= probability) return bit;
+        return bit === "0" ? "1" : "0";
+      })
+      .join(""),
+  );
 };
 
 const probabilityOfIndex = (sim: QuantumSimulator, index: number): number => {
@@ -318,11 +376,12 @@ export class DensityCpuCircuitExecutor implements CircuitExecutor {
     }
 
     const sim = new DensityMatrixSimulator(circuit.qubitCount);
+    const resolvedNoise = resolveNoiseSettings(noiseModel);
 
-    const maybeApplyDepolarizingNoise = (qubits: number[]): void => {
-      if (!noiseModel || noiseModel.kind === "ideal") return;
+    const maybeApplyNoise = (qubits: number[]): void => {
       for (const qubit of qubits) {
-        sim.applySingleQubitDepolarizing(qubit, noiseModel.probability);
+        sim.applySingleQubitDepolarizing(qubit, resolvedNoise.depolarizingProbability);
+        sim.applySingleQubitAmplitudeDamping(qubit, resolvedNoise.amplitudeDampingProbability);
       }
     };
 
@@ -330,15 +389,15 @@ export class DensityCpuCircuitExecutor implements CircuitExecutor {
       switch (operation.kind) {
         case "rx":
           sim.applyRx(operation.qubit, operation.theta);
-          maybeApplyDepolarizingNoise([operation.qubit]);
+          maybeApplyNoise([operation.qubit]);
           break;
         case "ry":
           sim.applyRy(operation.qubit, operation.theta);
-          maybeApplyDepolarizingNoise([operation.qubit]);
+          maybeApplyNoise([operation.qubit]);
           break;
         case "xx":
           sim.applyXX(operation.q1, operation.q2, operation.theta);
-          maybeApplyDepolarizingNoise([operation.q1, operation.q2]);
+          maybeApplyNoise([operation.q1, operation.q2]);
           break;
         default: {
           const exhaustiveCheck: never = operation;
@@ -375,7 +434,10 @@ export class DensityCpuCircuitExecutor implements CircuitExecutor {
           ? {
               kind: "all-qubits",
               shots: measurement.shots,
-              bitstrings: probabilitiesToBitstrings(sim.measurementProbabilities(), circuit.qubitCount, measurement.shots),
+              bitstrings: applyReadoutError(
+                probabilitiesToBitstrings(sim.measurementProbabilities(), circuit.qubitCount, measurement.shots),
+                resolvedNoise.readoutErrorProbability,
+              ),
             }
           : undefined,
     };

--- a/src/lib/densityMatrixSimulator.test.ts
+++ b/src/lib/densityMatrixSimulator.test.ts
@@ -111,6 +111,21 @@ describe("DensityMatrixSimulator", () => {
     expect(afterNoise).toBeCloseTo(-0.6, 9);
   });
 
+  it("applies single-qubit amplitude damping to relax excited-state population", () => {
+    const simulator = new DensityMatrixSimulator(1);
+    simulator.applyRx(0, Math.PI);
+
+    expect(simulator.expZ(0)).toBeCloseTo(-1, 9);
+
+    simulator.applySingleQubitAmplitudeDamping(0, 0.3);
+
+    expect(simulator.expZ(0)).toBeCloseTo(-0.4, 9);
+    expect(simulator.measurementProbabilities()).toEqual([
+      expect.closeTo(0.3, 9),
+      expect.closeTo(0.7, 9),
+    ]);
+  });
+
   it("preserves normalized non-negative populations under multi-qubit depolarizing noise", () => {
     const simulator = new DensityMatrixSimulator(2);
     simulator.applyRy(0, Math.PI / 2);
@@ -131,6 +146,26 @@ describe("DensityMatrixSimulator", () => {
     expect(Math.abs(simulator.expZ(1))).toBeLessThanOrEqual(1 + 1e-12);
     expect(Math.abs(simulator.expZZ(0, 1))).toBeLessThanOrEqual(1 + 1e-12);
     expect(Math.abs(simulator.expXX(0, 1))).toBeLessThanOrEqual(1 + 1e-12);
+  });
+
+  it("preserves normalized non-negative populations under mixed depolarizing and amplitude-damping noise", () => {
+    const simulator = new DensityMatrixSimulator(2);
+    simulator.applyRy(0, Math.PI / 2);
+    simulator.applyRx(1, Math.PI / 3);
+    simulator.applyXX(0, 1, Math.PI / 4);
+    simulator.applySingleQubitDepolarizing(0, 0.12);
+    simulator.applySingleQubitAmplitudeDamping(0, 0.08);
+    simulator.applySingleQubitDepolarizing(1, 0.05);
+    simulator.applySingleQubitAmplitudeDamping(1, 0.15);
+
+    const probabilities = simulator.measurementProbabilities();
+    const totalProbability = probabilities.reduce((sum, probability) => sum + probability, 0);
+
+    expect(totalProbability).toBeCloseTo(1, 12);
+    probabilities.forEach((probability) => {
+      expect(probability).toBeGreaterThanOrEqual(-1e-12);
+      expect(probability).toBeLessThanOrEqual(1 + 1e-12);
+    });
   });
 });
 

--- a/src/lib/densityMatrixSimulator.ts
+++ b/src/lib/densityMatrixSimulator.ts
@@ -58,6 +58,16 @@ const conjugateTranspose = (matrix: ComplexMatrix): ComplexMatrix => {
 const applyUnitaryToDensityMatrix = (densityMatrix: ComplexMatrix, unitary: ComplexMatrix): ComplexMatrix =>
   matrixMultiply(matrixMultiply(unitary, densityMatrix), conjugateTranspose(unitary));
 
+const applyKrausChannelToDensityMatrix = (densityMatrix: ComplexMatrix, operators: ComplexMatrix[]): ComplexMatrix =>
+  operators.reduce(
+    (sum, operator) =>
+      matrixAdd(
+        sum,
+        matrixMultiply(matrixMultiply(operator, densityMatrix), conjugateTranspose(operator)),
+      ),
+    zeroMatrix(densityMatrix.length),
+  );
+
 const kron = (a: ComplexMatrix, b: ComplexMatrix): ComplexMatrix => {
   const aDimension = a.length;
   const bDimension = b.length;
@@ -114,6 +124,17 @@ const PAULI_Y: ComplexMatrix = [
 const PAULI_Z: ComplexMatrix = [
   [complex(1), complex(0)],
   [complex(0), complex(-1)],
+];
+
+const amplitudeDampingOperators = (probability: number): [ComplexMatrix, ComplexMatrix] => [
+  [
+    [complex(1), complex(0)],
+    [complex(0), complex(Math.sqrt(1 - probability))],
+  ],
+  [
+    [complex(0), complex(Math.sqrt(probability))],
+    [complex(0), complex(0)],
+  ],
 ];
 
 const XX = (theta: number): ComplexMatrix => {
@@ -247,6 +268,17 @@ export class DensityMatrixSimulator {
       matrixScale(this.densityMatrix, 1 - probability),
       matrixScale(mixedContribution, probability / 3),
     );
+  }
+
+  applySingleQubitAmplitudeDamping(qubit: number, probability: number): void {
+    assertValidQubitIndex(this.nQubits, qubit);
+    if (probability <= 0) return;
+
+    const [e0, e1] = amplitudeDampingOperators(probability);
+    this.densityMatrix = applyKrausChannelToDensityMatrix(this.densityMatrix, [
+      embedSingleQubitOperator(this.nQubits, qubit, e0),
+      embedSingleQubitOperator(this.nQubits, qubit, e1),
+    ]);
   }
 
   expZ(qubit: number): number {

--- a/src/lib/noiseProfiles.ts
+++ b/src/lib/noiseProfiles.ts
@@ -1,0 +1,98 @@
+export type NoiseProfileId = "ideal" | "superconducting-like" | "trapped-ion-like" | "custom";
+
+export type NoiseSettings = {
+  depolarizingProbability: number;
+  amplitudeDampingProbability: number;
+  readoutErrorProbability: number;
+};
+
+export type NoiseProfileDescriptor = {
+  id: NoiseProfileId;
+  label: string;
+  settings: NoiseSettings;
+};
+
+export const DEFAULT_CUSTOM_NOISE_SETTINGS: NoiseSettings = {
+  depolarizingProbability: 0.05,
+  amplitudeDampingProbability: 0.02,
+  readoutErrorProbability: 0.01,
+};
+
+const IDEAL_NOISE_SETTINGS: NoiseSettings = {
+  depolarizingProbability: 0,
+  amplitudeDampingProbability: 0,
+  readoutErrorProbability: 0,
+};
+
+const NOISE_PROFILE_DESCRIPTORS: Record<Exclude<NoiseProfileId, "custom">, NoiseProfileDescriptor> = {
+  ideal: {
+    id: "ideal",
+    label: "Ideal simulator",
+    settings: IDEAL_NOISE_SETTINGS,
+  },
+  "superconducting-like": {
+    id: "superconducting-like",
+    label: "Superconducting-like",
+    settings: {
+      depolarizingProbability: 0.03,
+      amplitudeDampingProbability: 0.08,
+      readoutErrorProbability: 0.04,
+    },
+  },
+  "trapped-ion-like": {
+    id: "trapped-ion-like",
+    label: "Trapped-ion-like",
+    settings: {
+      depolarizingProbability: 0.008,
+      amplitudeDampingProbability: 0.015,
+      readoutErrorProbability: 0.012,
+    },
+  },
+};
+
+const clampProbability = (value: unknown, fallback: number): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(1, Math.max(0, value));
+};
+
+export const isValidNoiseProfileId = (value: unknown): value is NoiseProfileId =>
+  value === "ideal" || value === "superconducting-like" || value === "trapped-ion-like" || value === "custom";
+
+export const normalizeNoiseSettings = (
+  settings: Partial<NoiseSettings> | undefined,
+  fallback: NoiseSettings = DEFAULT_CUSTOM_NOISE_SETTINGS,
+): NoiseSettings => ({
+  depolarizingProbability: clampProbability(settings?.depolarizingProbability, fallback.depolarizingProbability),
+  amplitudeDampingProbability: clampProbability(
+    settings?.amplitudeDampingProbability,
+    fallback.amplitudeDampingProbability,
+  ),
+  readoutErrorProbability: clampProbability(settings?.readoutErrorProbability, fallback.readoutErrorProbability),
+});
+
+export const listNoiseProfiles = (): NoiseProfileDescriptor[] => [
+  NOISE_PROFILE_DESCRIPTORS.ideal,
+  NOISE_PROFILE_DESCRIPTORS["superconducting-like"],
+  NOISE_PROFILE_DESCRIPTORS["trapped-ion-like"],
+  {
+    id: "custom",
+    label: "Custom",
+    settings: DEFAULT_CUSTOM_NOISE_SETTINGS,
+  },
+];
+
+export const getNoiseProfileDescriptor = (profileId: NoiseProfileId): NoiseProfileDescriptor =>
+  profileId === "custom"
+    ? {
+        id: "custom",
+        label: "Custom",
+        settings: DEFAULT_CUSTOM_NOISE_SETTINGS,
+      }
+    : NOISE_PROFILE_DESCRIPTORS[profileId];
+
+export const resolveNoiseSettingsForProfile = (
+  profileId: NoiseProfileId,
+  customSettings: NoiseSettings,
+): NoiseSettings => (profileId === "custom" ? customSettings : getNoiseProfileDescriptor(profileId).settings);

--- a/src/lib/providerAuth.test.ts
+++ b/src/lib/providerAuth.test.ts
@@ -11,8 +11,10 @@ import {
 const makePreferences = (overrides?: Partial<BackendPreferences>): BackendPreferences => ({
   executionTarget: "dense-cpu",
   ionqCredentialMode: "browser-session",
-  noiseModelKind: "ideal",
+  noiseProfileId: "ideal",
   depolarizingProbability: 0.05,
+  amplitudeDampingProbability: 0.02,
+  readoutErrorProbability: 0.01,
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary
- add hardware-style local noise presets for the density backend
- support composite local noise with depolarizing, amplitude damping, and readout error
- extend simulator and app tests so the richer local noise path stays covered

Progress on #2